### PR TITLE
Mark stack as non executable

### DIFF
--- a/src/Make.inc
+++ b/src/Make.inc
@@ -35,12 +35,11 @@ else
 endif
 
 LBT_CFLAGS := -g -O2 -std=c99 -fPIC -DLIBRARY_EXPORTS -D_GNU_SOURCE $(CFLAGS)
-# Linker doesn't detect automatically executable stack isn't needed
-LBT_LDFLAGS := $(LDFLAGS) -Wl,-z,noexecstack
 
 ifeq ($(OS),Linux)
 # On linux, we need to link `libdl` to get `dlopen`
-LBT_LDFLAGS += -ldl
+# and linker doesn't detect automatically executable stack isn't needed
+LBT_LDFLAGS += -ldl -Wl,-z,noexecstack
 endif
 
 ifeq ($(OS),WINNT)

--- a/src/Make.inc
+++ b/src/Make.inc
@@ -35,7 +35,8 @@ else
 endif
 
 LBT_CFLAGS := -g -O2 -std=c99 -fPIC -DLIBRARY_EXPORTS -D_GNU_SOURCE $(CFLAGS)
-LBT_LDFLAGS := $(LDFLAGS)
+# Linker doesn't detect automatically executable stack isn't needed
+LBT_LDFLAGS := $(LDFLAGS) -Wl,-z,noexecstack
 
 ifeq ($(OS),Linux)
 # On linux, we need to link `libdl` to get `dlopen`


### PR DESCRIPTION
The linker is unable to detect that executable stack is not required and so marks libblastrampoline.so as requiring it. Pass `-Wl,-z,noexecstack` to ensure that the stack is marked as not executable. This improves security and allows running on systems where SELinux has been configured to disallow executable stacks.