### PR TITLE
Revert mistaken removal of `LBT_LDFLAGS` line

### DIFF
--- a/src/Make.inc
+++ b/src/Make.inc
@@ -35,6 +35,7 @@ else
 endif
 
 LBT_CFLAGS := -g -O2 -std=c99 -fPIC -DLIBRARY_EXPORTS -D_GNU_SOURCE $(CFLAGS)
+LBT_LDFLAGS := $(LDFLAGS)
 
 ifeq ($(OS),Linux)
 # On linux, we need to link `libdl` to get `dlopen`


### PR DESCRIPTION
Introduced by https://github.com/JuliaLinearAlgebra/libblastrampoline/pull/51.