### PR TITLE
Add test for how to directly load new MKL ILP64

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ You can always tell if your system is limited in this fashion by calling `lbt_ge
 
 ### Version History
 
+v4.0.0 - Add `suffix_hint` parameter to `lbt_forward()` to allow overriding symbol suffix search order for dual-interface libraries, and allow loading the same library with multiple interfaces.
+
 v3.1.0 - Add `LBT_USE_RTLD_DEEPBIND` environment variable override (for santizer usage), and add buildsystem fixes for Haiku.
 
 v3.0.4 - Fix armv7l interface autodetection.

--- a/src/config.c
+++ b/src/config.c
@@ -77,8 +77,10 @@ void record_library_load(const char * libname, void * handle, const char * suffi
             free_idx = idx;
             break;
         }
-        // If this library has been loaded before, all we do is copy the `forwards` over
-        if (lbt_config.loaded_libs[idx]->handle == handle) {
+        // If this library has been loaded before, and the interface matches, all we do is copy the `forwards` over
+        // We check interface matching because it is possible for a single library to contain both LP64 and ILP64
+        // symbols, and we want to treat both of those as separate.
+        if (lbt_config.loaded_libs[idx]->handle == handle && lbt_config.loaded_libs[idx]->interface == interface) {
             memcpy(lbt_config.loaded_libs[idx]->active_forwards, forwards, sizeof(uint8_t)*(NUM_EXPORTED_FUNCS/8 + 1));
             clear_other_forwards(idx, forwards, interface);
             return;

--- a/src/libblastrampoline.c
+++ b/src/libblastrampoline.c
@@ -147,7 +147,7 @@ LBT_DLLEXPORT int32_t lbt_set_forward(const char * symbol_name, const void * add
 /*
  * Load `libname`, clearing previous mappings if `clear` is set.
  */
-LBT_DLLEXPORT int32_t lbt_forward(const char * libname, int32_t clear, int32_t verbose) {
+LBT_DLLEXPORT int32_t lbt_forward(const char * libname, int32_t clear, int32_t verbose, const char * suffix_hint) {
     if (verbose) {
         printf("Generating forwards to %s\n", libname);
     }
@@ -161,7 +161,7 @@ LBT_DLLEXPORT int32_t lbt_forward(const char * libname, int32_t clear, int32_t v
 
     // Once we have the BLAS/LAPACK library loaded, we need to autodetect a few things about it.
     // First, we are going to figure out its name-mangling suffix:
-    const char * lib_suffix = autodetect_symbol_suffix(handle);
+    const char * lib_suffix = autodetect_symbol_suffix(handle, suffix_hint);
     if (lib_suffix == NULL) {
         fprintf(stderr, "Unable to autodetect symbol suffix of \"%s\"\n", libname);
         return 0;
@@ -340,7 +340,7 @@ __attribute__((constructor)) void init(void) {
                 curr_lib_start++;
 
             // Load functions from this library, clearing only the first time.
-            lbt_forward(curr_lib, clear, verbose);
+            lbt_forward(curr_lib, clear, verbose, NULL);
             clear = 0;
         }
     }

--- a/src/libblastrampoline.h
+++ b/src/libblastrampoline.h
@@ -106,8 +106,12 @@ typedef struct {
  * support in the system libc for more details.
  *
  * If `verbose` is set to a non-zero value, it will print out debugging information.
+ *
+ * If `suffix_hint` is set to a non-NULL value, it is the first suffix that is used to search for
+ * BLAS/LAPACK symbols within the library.  This is useful in case a library contains within it both
+ * LP64 and ILP64 symbols, and you want to prefer one set of symbols over the other.
  */
-LBT_DLLEXPORT int32_t lbt_forward(const char * libname, int32_t clear, int32_t verbose);
+LBT_DLLEXPORT int32_t lbt_forward(const char * libname, int32_t clear, int32_t verbose, const char * suffix_hint);
 
 /*
  * Returns a structure describing the currently-loaded libraries as well as the build configuration

--- a/src/libblastrampoline_internal.h
+++ b/src/libblastrampoline_internal.h
@@ -73,7 +73,7 @@ void * lookup_symbol(const void * lib_handle, const char * symbol_name);
 void close_library(void * handle);
 
 // Functions in `autodetection.c`
-const char * autodetect_symbol_suffix(void * handle);
+const char * autodetect_symbol_suffix(void * handle, const char * suffix_hint);
 int32_t autodetect_blas_interface(void * isamax_addr);
 int32_t autodetect_lapack_interface(void * dpotrf_addr);
 int32_t autodetect_interface(void * handle, const char * suffix);

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -32,9 +32,10 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JLLWrappers]]
-git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
+deps = ["Preferences"]
+git-tree-sha1 = "22df5b96feef82434b07327e2d3c770a9b21e023"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.2.0"
+version = "1.4.0"
 
 [[LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -64,9 +65,9 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[MKL_jll]]
 deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
-git-tree-sha1 = "c253236b0ed414624b083e6b72bfe891fbd2c7af"
+git-tree-sha1 = "e595b205efd49508358f7dc670a940c790204629"
 uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
-version = "2021.1.1+1"
+version = "2022.0.0+0"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -84,17 +85,23 @@ uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
 [[OpenBLAS32_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ba4a8f683303c9082e84afba96f25af3c7fb2436"
+git-tree-sha1 = "9c6c2ed4b7acd2137b878eb96c68e63b76199d0f"
 uuid = "656ef2d0-ae68-5445-9ca0-591084a874a2"
-version = "0.3.12+1"
+version = "0.3.17+0"
 
 [[OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 
 [[Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs"]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "2cf929d64681236a2e074ffafb8d568733d2e6af"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.3"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -105,7 +112,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[SHA]]
@@ -139,3 +146,7 @@ uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 [[nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -102,8 +102,8 @@ struct lbt_config_t
 end
 const LBT_BUILDFLAGS_F2C_CAPABLE = 0x02
 
-function lbt_forward(handle, path; clear::Bool = false, verbose::Bool = false)
-    ccall(dlsym(handle, :lbt_forward), Int32, (Cstring, Int32, Int32), path, clear ? 1 : 0, verbose ? 1 : 0)
+function lbt_forward(handle, path; clear::Bool = false, verbose::Bool = false, suffix_hint::Union{Nothing,String} = nothing)
+    ccall(dlsym(handle, :lbt_forward), Int32, (Cstring, Int32, Int32, Cstring), path, clear ? 1 : 0, verbose ? 1 : 0, something(suffix_hint, C_NULL))
 end
 
 function lbt_get_config(handle)


### PR DESCRIPTION
MKL added a new library in v2022 that allows us to directly link against
a library that provides ILP64-namespaced symbols.