### PR TITLE
Add `LBT_STRICT` environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
   gensymbol:
     name: generate_func_list idempotency
     runs-on: ubuntu-20.04
-  steps:
-    - uses: actions/checkout@v2
-    - name: Check exported symbols up to date
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check exported symbols up to date
         shell: bash
         run: |
           cd ext/gensymbol

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ You can always tell if your system is limited in this fashion by calling `lbt_ge
 
 ### Version History
 
+v4.1.0 - Add `LBT_STRICT` environment variable that causes calling missing symbols to kill the process.
+
 v4.0.0 - Add `suffix_hint` parameter to `lbt_forward()` to allow overriding symbol suffix search order for dual-interface libraries, and allow loading the same library with multiple interfaces.
 
 v3.1.0 - Add `LBT_USE_RTLD_DEEPBIND` environment variable override (for santizer usage), and add buildsystem fixes for Haiku.

--- a/src/autodetection.c
+++ b/src/autodetection.c
@@ -18,12 +18,13 @@ const char * autodetect_symbol_suffix(void * handle, const char * suffix_hint) {
         // Possibly-NULL suffix that we should search over
         suffix_hint,
 
-        // Search for ILP64-mangling suffixes first, as in the rare case that we want to
-        // load a library that exports both, we prefer to bind to the namespaced symbols first
-        "64", "64_", "_64__", "__64___",
-
-        // Next, LP64-mangling suffixes
+        // First, search for LP64-mangling suffixes, so that when we are loading MKL from a
+        // CLI environment, (where suffix hints are not easy) we want to give the most stable
+        // configuration by default.
         "", "_", "__",
+
+        // Next, search for ILP64-mangling suffixes
+        "64", "64_", "_64__", "__64___",
     };
 
     // If the suffix hint is NULL, just skip it when calling `lookup_symbol()`.

--- a/src/dl_utils.c
+++ b/src/dl_utils.c
@@ -1,5 +1,4 @@
 #include "libblastrampoline_internal.h"
-#include <dlfcn.h>
 
 void throw_dl_error(const char * path) {
     fprintf(stderr, "ERROR: Unable to load dependent library %s\n", path);
@@ -87,6 +86,10 @@ void * lookup_self_symbol(const char * symbol_name) {
     void * self_handle = NULL;
 #if defined(_OS_WINDOWS_)
     self_handle = GetModuleHandle(NULL);
+#elif defined(_OS_DARWIN_)
+    self_handle = RTLD_SELF;
+#elif defined(RTLD_DEFAULT)
+    self_handle = RTLD_DEFAULT;
 #endif
     return lookup_symbol(self_handle, symbol_name);
 }

--- a/src/dl_utils.c
+++ b/src/dl_utils.c
@@ -77,3 +77,15 @@ void * lookup_symbol(const void * handle, const char * symbol_name) {
     return dlsym((void *)handle, symbol_name);
 #endif
 }
+
+/*
+ * Work around protected symbol visibility and GCC/ld.bfd bug:
+ * https://sourceware.org/bugzilla/show_bug.cgi?id=26815
+ */
+void * lookup_self_symbol(const char * symbol_name) {
+    void * self_handle = NULL;
+#if defined(_OS_WINDOWS_)
+    self_handle = GetModuleHandle(NULL);
+#endif
+    return lookup_symbol(self_handle, symbol_name);
+}

--- a/src/libblastrampoline.c
+++ b/src/libblastrampoline.c
@@ -307,7 +307,7 @@ __attribute__((constructor)) void init(void) {
     const char * verbose_str = getenv("LBT_VERBOSE");
     if (verbose_str != NULL && strcmp(verbose_str, "1") == 0) {
         verbose = 1;
-        printf("libblastrampoline initializing\n");
+        printf("libblastrampoline initializing from %s\n", lookup_self_path());
     }
 
 #if !defined(LBT_DEEPBINDLESS)

--- a/src/libblastrampoline.h
+++ b/src/libblastrampoline.h
@@ -160,17 +160,16 @@ LBT_DLLEXPORT void lbt_register_thread_interface(const char * getter, const char
 LBT_DLLEXPORT void lbt_default_func_print_error();
 
 /*
+ * Function that prints out to `stderr` that someone called an uninitialized function, and
+ * then calls `exit(1)`.  This is used with `lbt_set_default_func()`.
+ */
+LBT_DLLEXPORT void lbt_default_func_print_error_and_exit();
+
+/*
  * Returns the currently-configured default function that gets called if no mapping has been set
  * for an exported symbol.  Can return `NULL` if it was set as the default function.
  */
 LBT_DLLEXPORT const void * lbt_get_default_func();
-
-/*
- * Users can force an RTLD_DEEPBIND-capable system to avoid using RTLD_DEEPBIND by setting
- * `LBT_USE_RTLD_DEEPBIND=0` in their environment.  This function returns `0x01` if it will
- *  use `RTLD_DEEPBIND` when loading a library, and `0x00` otherwise.
- */
- LBT_DLLEXPORT const uint8_t lbt_get_use_deepbind();
 
 /*
  * Sets the default function that gets called if no mapping has been set for an exported symbol.
@@ -179,6 +178,13 @@ LBT_DLLEXPORT const void * lbt_get_default_func();
  * this function immediately before calling `lbt_forward()` with `clear` set.
  */
 LBT_DLLEXPORT void lbt_set_default_func(const void * addr);
+
+/*
+ * Users can force an RTLD_DEEPBIND-capable system to avoid using RTLD_DEEPBIND by setting
+ * `LBT_USE_RTLD_DEEPBIND=0` in their environment.  This function returns `0x01` if it will
+ *  use `RTLD_DEEPBIND` when loading a library, and `0x00` otherwise.
+ */
+ LBT_DLLEXPORT const uint8_t lbt_get_use_deepbind();
 
 /*
  * Returns the currently-configured forward target for the given `symbol_name`, according to the

--- a/src/libblastrampoline_internal.h
+++ b/src/libblastrampoline_internal.h
@@ -70,6 +70,7 @@ int utf8_to_wchar(const char * str, wchar_t * wstr, size_t maxlen);
 // Functions in `dl_utils.c`
 void * load_library(const char * path);
 void * lookup_symbol(const void * lib_handle, const char * symbol_name);
+void * lookup_self_symbol(const char * symbol_name);
 void close_library(void * handle);
 
 // Functions in `autodetection.c`

--- a/src/libblastrampoline_internal.h
+++ b/src/libblastrampoline_internal.h
@@ -71,6 +71,7 @@ int utf8_to_wchar(const char * str, wchar_t * wstr, size_t maxlen);
 void * load_library(const char * path);
 void * lookup_symbol(const void * lib_handle, const char * symbol_name);
 void * lookup_self_symbol(const char * symbol_name);
+const char * lookup_self_path();
 void close_library(void * handle);
 
 // Functions in `autodetection.c`

--- a/test/direct.jl
+++ b/test/direct.jl
@@ -28,8 +28,8 @@ function bitfield_get(field::Vector{UInt8}, symbol_idx::UInt32)
     return field[div(symbol_idx,8)+1] & (UInt8(0x01) << (symbol_idx%8))
 end
 
-lbt_prefix = get_blastrampoline_dir()
-lbt_handle = dlopen("$(lbt_prefix)/$(binlib)/libblastrampoline.$(shlib_ext)", RTLD_GLOBAL | RTLD_DEEPBIND)
+lbt_link_name, lbt_prefix = build_libblastrampoline()
+lbt_handle = dlopen("$(lbt_prefix)/$(binlib)/lib$(lbt_link_name).$(shlib_ext)", RTLD_GLOBAL | RTLD_DEEPBIND)
 
 @testset "Config" begin
     @test lbt_handle != C_NULL

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,7 +106,7 @@ lbt_link_name, lbt_dir = build_libblastrampoline()
 lbt_dir = joinpath(lbt_dir, binlib)
 
 @testset "LBT -> OpenBLAS_jll ($(openblas_interface))" begin
-    libdirs = unique(vcat(OpenBLAS_jll.LIBPATH_list..., CompilerSupportLibraries_jll.LIBPATH_list..., lbt_dir))
+    libdirs = unique(vcat(lbt_dir, OpenBLAS_jll.LIBPATH_list..., CompilerSupportLibraries_jll.LIBPATH_list...))
     run_test(dgemm, lbt_link_name, libdirs, openblas_interface, OpenBLAS_jll.libopenblas_path)
     run_test(sgesv, lbt_link_name, libdirs, openblas_interface, OpenBLAS_jll.libopenblas_path)
     run_test(sdot,  lbt_link_name, libdirs, openblas_interface, OpenBLAS_jll.libopenblas_path)
@@ -114,7 +114,7 @@ end
 
 # And again, but this time with OpenBLAS32_jll
 @testset "LBT -> OpenBLAS32_jll (LP64)" begin
-    libdirs = unique(vcat(OpenBLAS32_jll.LIBPATH_list..., CompilerSupportLibraries_jll.LIBPATH_list..., lbt_dir))
+    libdirs = unique(vcat(lbt_dir, OpenBLAS32_jll.LIBPATH_list..., CompilerSupportLibraries_jll.LIBPATH_list...))
     run_test(dgemm, lbt_link_name, libdirs, :LP64, OpenBLAS32_jll.libopenblas_path)
     run_test(sgesv, lbt_link_name, libdirs, :LP64, OpenBLAS32_jll.libopenblas_path)
     run_test(sdot,  lbt_link_name, libdirs, :LP64, OpenBLAS32_jll.libopenblas_path)
@@ -123,7 +123,7 @@ end
 # Test against MKL_jll using `libmkl_rt`, which is :LP64 by default
 if MKL_jll.is_available()
     @testset "LBT -> MKL_jll (LP64)" begin
-        libdirs = unique(vcat(MKL_jll.LIBPATH_list..., CompilerSupportLibraries_jll.LIBPATH_list..., lbt_dir))
+        libdirs = unique(vcat(lbt_dir, MKL_jll.LIBPATH_list..., CompilerSupportLibraries_jll.LIBPATH_list...))
         run_test(dgemm, lbt_link_name, libdirs, :LP64, MKL_jll.libmkl_rt_path)
         run_test(sgesv, lbt_link_name, libdirs, :LP64, MKL_jll.libmkl_rt_path)
         run_test(sdot,  lbt_link_name, libdirs, :LP64, MKL_jll.libmkl_rt_path)
@@ -133,7 +133,7 @@ if MKL_jll.is_available()
     if Sys.WORD_SIZE == 64
         @testset "LBT -> MKL_jll (ILP64, via env)" begin
             withenv("MKL_INTERFACE_LAYER" => "ILP64") do
-                libdirs = unique(vcat(MKL_jll.LIBPATH_list..., CompilerSupportLibraries_jll.LIBPATH_list..., lbt_dir))
+                libdirs = unique(vcat(lbt_dir, MKL_jll.LIBPATH_list..., CompilerSupportLibraries_jll.LIBPATH_list...))
                 run_test(dgemm, lbt_link_name, libdirs, :ILP64, MKL_jll.libmkl_rt_path)
                 run_test(sgesv, lbt_link_name, libdirs, :ILP64, MKL_jll.libmkl_rt_path)
                 run_test(sdot,  lbt_link_name, libdirs, :ILP64, MKL_jll.libmkl_rt_path)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -56,7 +56,7 @@ needs_m32() = startswith(last(capture_output(`$(cc) -dumpmachine`)), "x86_64") &
 
 # Build blastrampoline into a temporary directory, and return that
 blastrampoline_build_dir = nothing
-function get_blastrampoline_dir()
+function build_libblastrampoline()
     if blastrampoline_build_dir !== nothing
         return blastrampoline_build_dir
     end
@@ -66,8 +66,17 @@ function get_blastrampoline_dir()
     srcdir = joinpath(dirname(@__DIR__), "src")
     run(`$(make) -sC $(pathesc(srcdir)) CFLAGS=$(cflags_add) ARCH=$(Sys.ARCH) clean`)
     run(`$(make) -sC $(pathesc(srcdir)) CFLAGS=$(cflags_add) ARCH=$(Sys.ARCH) install builddir=$(pathesc(dir))/build prefix=$(pathesc(dir))/output`)
+
     global blastrampoline_build_dir = joinpath(dir, "output")
-    return blastrampoline_build_dir
+
+    # Give LBT a fake linking name so that we can test from within Julia versions that actually load LBT natively.
+    link_name = "blastramp-dev"
+    cp(
+        joinpath(blastrampoline_build_dir, binlib, "libblastrampoline.$(shlib_ext)"),
+        joinpath(blastrampoline_build_dir, binlib, "lib$(link_name).$(shlib_ext)"),
+    )
+    println("$(blastrampoline_build_dir)/$(binlib)")
+    return link_name, blastrampoline_build_dir
 end
 
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -32,7 +32,7 @@ function capture_output(cmd::Cmd; verbose::Bool = false)
     close(out_pipe.in)
     output = @async read(out_pipe, String)
     wait(p)
-    return fetch(output)
+    return p, fetch(output)
 end
 
 cc = something(
@@ -51,7 +51,7 @@ else
     make = "make"
 end
 
-needs_m32() = startswith(capture_output(`$(cc) -dumpmachine`), "x86_64") && Sys.WORD_SIZE == 32
+needs_m32() = startswith(last(capture_output(`$(cc) -dumpmachine`)), "x86_64") && Sys.WORD_SIZE == 32
 
 
 # Build blastrampoline into a temporary directory, and return that


### PR DESCRIPTION
This causes calling missing symbols to kill the process; useful for
testing and debugging.  The same effect can be found by using
`lbt_set_default_func()`; this simply allows for an easy switch for CLI
users.