### PR TITLE
Use strdup to copy strings

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -40,10 +40,8 @@ LBT_DLLEXPORT void lbt_register_thread_interface(const char * getter, const char
         idx++;
     }
 
-    getter_names[idx] = (char *) malloc(strlen(getter));
-    strcpy(getter_names[idx], getter);
-    setter_names[idx] = (char *) malloc(strlen(setter));
-    strcpy(setter_names[idx], setter);
+    getter_names[idx] = strdup(getter);
+    setter_names[idx] = strdup(setter);
 }
 
 /*


### PR DESCRIPTION
The previous code failed to allocate space for the terminal NUL byte.

This started to cause a build failure on archlinux build bot a yesterday.