### PR TITLE
Fix incompatible pointer conversion on gcc 12.1.0

### DIFF
--- a/src/dl_utils.c
+++ b/src/dl_utils.c
@@ -3,7 +3,7 @@
 void throw_dl_error(const char * path) {
     fprintf(stderr, "ERROR: Unable to load dependent library %s\n", path);
 #if defined(_OS_WINDOWS_)
-    LPWSTR wmsg = TEXT("");
+    LPWSTR wmsg = NULL;
     FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER |
                     FORMAT_MESSAGE_FROM_SYSTEM |
                     FORMAT_MESSAGE_IGNORE_INSERTS |


### PR DESCRIPTION
This line of code cannot be compiled under x86_64-w64-mingw32-gcc 12.1.0
Error message
```
x86_64-w64-mingw32-gcc -m64 -o build/dl_utils.o -g -O2 -Werror -std=c99 -fPIC -DLIBRARY_EXPORTS -D_GNU_SOURCE -DF2C_AUTODETECTION -DCBLAS_DIVERGENCE_AUTODETECTION -DCOMPLEX_RETSTYLE_AUTODETECTION -c dl_utils.c
In file included from /usr/x86_64-w64-mingw32/include/minwindef.h:163,
                 from /usr/x86_64-w64-mingw32/include/windef.h:9,
                 from /usr/x86_64-w64-mingw32/include/windows.h:69,
                 from libblastrampoline_internal.h:18,
                 from dl_utils.c:1:
dl_utils.c: In function 'throw_dl_error':
dl_utils.c:6:24: error: initialization of 'LPWSTR' {aka 'short unsigned int *'} from incompatible pointer type 'char *' [-Werror=incompatible-pointer-types]
    6 |     LPWSTR wmsg = TEXT("");
      |                        ^~
cc1: all warnings being treated as errors
```

gcc version:
```
$ x86_64-w64-mingw32-gcc -v
Using built-in specs.
COLLECT_GCC=x86_64-w64-mingw32-gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-w64-mingw32/12.1.0/lto-wrapper
Target: x86_64-w64-mingw32
Configured with: /build/mingw-w64-gcc/src/gcc/configure --prefix=/usr --libexecdir=/usr/lib --target=x86_64-w64-mingw32 --with-bugurl=https://bugs.archlinux.org/ --enable-languages=c,lto,c++,ada,objc,obj-c++,fortran --enable-shared --enable-static --enable-threads=posix --enable-fully-dynamic-string --enable-libstdcxx-time=yes --enable-libstdcxx-filesystem-ts=yes --with-system-zlib --enable-cloog-backend=isl --enable-lto --enable-libgomp --disable-multilib --enable-checking=release --disable-sjlj-exceptions --with-dwarf2
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.1.0 (GCC)
```