### PR TITLE
Preallocate enough space for null terminated string

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -40,9 +40,9 @@ LBT_DLLEXPORT void lbt_register_thread_interface(const char * getter, const char
         idx++;
     }
 
-    getter_names[idx] = (char *) malloc(strlen(getter));
+    getter_names[idx] = (char *) malloc(strlen(getter) + 1);
     strcpy(getter_names[idx], getter);
-    setter_names[idx] = (char *) malloc(strlen(setter));
+    setter_names[idx] = (char *) malloc(strlen(setter) + 1);
     strcpy(setter_names[idx], setter);
 }
 


### PR DESCRIPTION
Error on x86_64-w64-mingw32-gcc 12.1.0
```
x86_64-w64-mingw32-gcc -m64 -o build/threading.o -g -O2 -Werror -std=c99 -fPIC -DLIBRARY_EXPORTS -D_GNU_SOURCE -DF2C_AUTODETECTION -DCBLAS_DIVERGENCE_AUTODETECTION -DCOMPLEX_RETSTYLE_AUTODETECTION -c threading.c
threading.c: In function 'lbt_register_thread_interface':
threading.c:44:5: error: 'strcpy' writing one too many bytes into a region of a size that depends on 'strlen' [-Werror=stringop-overflow=]
   44 |     strcpy(getter_names[idx], getter);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
threading.c:43:34: note: destination object of size [0, 9223372036854775805] allocated by 'malloc'
   43 |     getter_names[idx] = (char *) malloc(strlen(getter));
      |                                  ^~~~~~~~~~~~~~~~~~~~~~
threading.c:46:5: error: 'strcpy' writing one too many bytes into a region of a size that depends on 'strlen' [-Werror=stringop-overflow=]
   46 |     strcpy(setter_names[idx], setter);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
threading.c:45:34: note: destination object of size [0, 9223372036854775805] allocated by 'malloc'
   45 |     setter_names[idx] = (char *) malloc(strlen(setter));
      |                                  ^~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

gcc version:
```
$ x86_64-w64-mingw32-gcc -v
Using built-in specs.
COLLECT_GCC=x86_64-w64-mingw32-gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-w64-mingw32/12.1.0/lto-wrapper
Target: x86_64-w64-mingw32
Configured with: /build/mingw-w64-gcc/src/gcc/configure --prefix=/usr --libexecdir=/usr/lib --target=x86_64-w64-mingw32 --with-bugurl=https://bugs.archlinux.org/ --enable-languages=c,lto,c++,ada,objc,obj-c++,fortran --enable-shared --enable-static --enable-threads=posix --enable-fully-dynamic-string --enable-libstdcxx-time=yes --enable-libstdcxx-filesystem-ts=yes --with-system-zlib --enable-cloog-backend=isl --enable-lto --enable-libgomp --disable-multilib --enable-checking=release --disable-sjlj-exceptions --with-dwarf2
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.1.0 (GCC)
```