### PR TITLE
Fix composition of f2c and complex return style in Apple Accelerate

### DIFF
--- a/src/f2c_adapters.c
+++ b/src/f2c_adapters.c
@@ -15,8 +15,6 @@
  *       - `s{,a,c,ca}sum`
  *       - `s{,c}nrm2`
  *       - `slamc{h,3}`
- *   - Pass an extra argument to store return value for the following BLAS functions:
- *       - `{c,z}dot{c,u}`
  */
 
 // smax
@@ -177,65 +175,4 @@ LBT_HIDDEN float f2c_slamc3_(const float * x, const float * y) {
 extern double (*f2c_slamc3_64__addr)(const float * x, const float * y);
 LBT_HIDDEN float f2c_slamc3_64_(const float * x, const float * y) {
 	return f2c_slamc3_64__addr(x, y);
-}
-
-
-// cdotc
-extern void (*f2c_cdotc__addr)(float complex *z, const int32_t *n, const float complex *x, const int32_t * ix, const float complex *y, const int32_t *iy);
-LBT_HIDDEN float complex f2c_cdotc_(const int32_t *n, const float complex *x, const int32_t * ix, const float complex *y, const int32_t *iy) {
-	float complex z;
-	f2c_cdotc__addr(&z, n, x, ix, y, iy);
-	return z;
-}
-extern void (*f2c_cdotc_64__addr)(float complex *z, const int64_t *n, const float complex *x, const int64_t * ix, const float complex *y, const int64_t *iy);
-LBT_HIDDEN float complex f2c_cdotc_64_(const int64_t *n, const float complex *x, const int64_t * ix, const float complex *y, const int64_t *iy) {
-	float complex z;
-	f2c_cdotc_64__addr(&z, n, x, ix, y, iy);
-	return z;
-}
-
-// cdotu
-extern void (*f2c_cdotu__addr)(float complex *z, const int32_t *n, const float complex *x, const int32_t * ix, const float complex *y, const int32_t *iy);
-float complex f2c_cdotu_(const int32_t* n, const float complex* x, const int32_t* ix, const float complex *y, const int32_t *iy)
-{
-	float complex z;
-	f2c_cdotu__addr(&z, n, x, ix, y, iy);
-	return z;
-}
-extern void (*f2c_cdotu_64__addr)(float complex *z, const int64_t *n, const float complex *x, const int64_t * ix, const float complex *y, const int64_t *iy);
-float complex f2c_cdotu_64_(const int64_t* n, const float complex* x, const int64_t* ix, const float complex *y, const int64_t *iy)
-{
-	float complex z;
-	f2c_cdotu_64__addr(&z, n, x, ix, y, iy);
-	return z;
-}
-
-// zdotc
-extern void (*f2c_zdotc__addr)(double complex *z, const int32_t *n, const double complex *x, const int32_t * ix, const double complex *y, const int32_t *iy);
-LBT_HIDDEN double complex f2c_zdotc_(const int32_t *n, const double complex *x, const int32_t * ix, const double complex *y, const int32_t *iy) {
-	double complex z;
-	f2c_zdotc__addr(&z, n, x, ix, y, iy);
-	return z;
-}
-extern void (*f2c_zdotc_64__addr)(double complex *z, const int64_t *n, const double complex *x, const int64_t * ix, const double complex *y, const int64_t *iy);
-LBT_HIDDEN double complex f2c_zdotc_64_(const int64_t *n, const double complex *x, const int64_t * ix, const double complex *y, const int64_t *iy) {
-	double complex z;
-	f2c_zdotc_64__addr(&z, n, x, ix, y, iy);
-	return z;
-}
-
-// zdotu
-extern void (*f2c_zdotu__addr)(double complex *z, const int32_t *n, const double complex *x, const int32_t * ix, const double complex *y, const int32_t *iy);
-double complex f2c_zdotu_(const int32_t* n, const double complex* x, const int32_t* ix, const double complex *y, const int32_t *iy)
-{
-	double complex z;
-	f2c_zdotu__addr(&z, n, x, ix, y, iy);
-	return z;
-}
-extern void (*f2c_zdotu_64__addr)(double complex *z, const int64_t *n, const double complex *x, const int64_t * ix, const double complex *y, const int64_t *iy);
-double complex f2c_zdotu_64_(const int64_t* n, const double complex* x, const int64_t* ix, const double complex *y, const int64_t *iy)
-{
-	double complex z;
-	f2c_zdotu_64__addr(&z, n, x, ix, y, iy);
-	return z;
 }

--- a/src/libblastrampoline_f2cdata.h
+++ b/src/libblastrampoline_f2cdata.h
@@ -3,10 +3,6 @@
 #define XX_64(name, idx) LBT_HIDDEN const void * f2c_##name##64__addr;
 FLOAT32_FUNCS(XX)
 FLOAT32_FUNCS(XX_64)
-COMPLEX64_FUNCS(XX)
-COMPLEX64_FUNCS(XX_64)
-COMPLEX128_FUNCS(XX)
-COMPLEX128_FUNCS(XX_64)
 #undef XX
 #undef XX_64
 
@@ -14,8 +10,6 @@ COMPLEX128_FUNCS(XX_64)
 #define XX(name, index)    index,
 const int f2c_func_idxs[] = {
     FLOAT32_FUNCS(XX)
-    COMPLEX64_FUNCS(XX)
-    COMPLEX128_FUNCS(XX)
     -1
 };
 #undef XX
@@ -26,10 +20,6 @@ const int f2c_func_idxs[] = {
 #define XX_64(name, index)  extern const void * f2c_##name##64_ ;
 FLOAT32_FUNCS(XX)
 FLOAT32_FUNCS(XX_64)
-COMPLEX64_FUNCS(XX)
-COMPLEX64_FUNCS(XX_64)
-COMPLEX128_FUNCS(XX)
-COMPLEX128_FUNCS(XX_64)
 #undef XX
 #undef XX_64
 
@@ -39,14 +29,10 @@ COMPLEX128_FUNCS(XX_64)
 #define XX_64(name, index) &f2c_##name##64_,
 const void ** f2c_func32_wrappers[] = {
     FLOAT32_FUNCS(XX)
-    COMPLEX64_FUNCS(XX)
-    COMPLEX128_FUNCS(XX)
     NULL
 };
 const void ** f2c_func64_wrappers[] = {
     FLOAT32_FUNCS(XX_64)
-    COMPLEX64_FUNCS(XX_64)
-    COMPLEX128_FUNCS(XX_64)
     NULL
 };
 #undef XX
@@ -57,14 +43,10 @@ const void ** f2c_func64_wrappers[] = {
 #define XX_64(name, index) &f2c_##name##64__addr,
 const void ** f2c_func32_addrs[] = {
     FLOAT32_FUNCS(XX)
-    COMPLEX64_FUNCS(XX)
-    COMPLEX128_FUNCS(XX)
     NULL
 };
 const void ** f2c_func64_addrs[] = {
     FLOAT32_FUNCS(XX_64)
-    COMPLEX64_FUNCS(XX_64)
-    COMPLEX128_FUNCS(XX_64)
     NULL
 };
 #undef XX

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,9 +142,11 @@ if MKL_jll.is_available()
     end
 end
 
-# Do we have Accelerate available?
+# Do we have Accelerate available?  Note that we can't use `isfile()` here, since Apple
+# has Helpfully (TM) sequestered the dynamic libraries away into a database somewhere that
+# just gets fed into `dlopen()` when you ask for that magic path.
 veclib_blas_path = "/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/libBLAS.dylib"
-if isfile(veclib_blas_path)
+if dlopen_e(veclib_blas_path) != C_NULL
     # Test that we can run BLAS-only tests without LAPACK loaded (`sgesv` test requires LAPACK symbols)
     @testset "LBT -> vecLib/libBLAS" begin
         run_all_tests("blastrampoline", [lbt_dir], :LP64, veclib_blas_path; tests=[dgemm, sdot, zdotc])


### PR DESCRIPTION
When I added complex return style detection in https://github.com/JuliaLinearAlgebra/libblastrampoline/pull/61 I failed to test it on an f2c BLAS such as Apple Accelerate, where I would have noticed that we were already applying a similar workaround there.  This cleanly separates the two concerns, and fixes macOS testing, which would have showcased the problem immediately.