### PR TITLE
Generate Windows import library for with major version only

### DIFF
--- a/src/Make.inc
+++ b/src/Make.inc
@@ -24,7 +24,7 @@ ifneq (,$(findstring MINGW,$(OS))$(findstring MSYS,$(OS))$(findstring CYGWIN,$(O
 endif
 
 LBT_SOVERSION_MAJOR := 5
-LBT_SOVERSION_MINOR := 0
+LBT_SOVERSION_MINOR := 1
 LBT_SOVERSION_PATCH := 2
 
 ifeq ($(OS), WINNT)

--- a/src/Makefile
+++ b/src/Makefile
@@ -43,7 +43,7 @@ dump-trampolines: trampolines/trampolines_$(ARCH).S
 
 
 $(builddir)/$(LIB_FULL_VERSION): $(MAIN_OBJS)
-	@$(call PRINT_CC,$(CC) -o "$@" $(call IMPLIB_FLAGS,$@) $(LBT_CFLAGS) $(SONAME_FLAG) $^ -shared $(LBT_LDFLAGS))
+	@$(call PRINT_CC,$(CC) -o "$@" $(call IMPLIB_FLAGS,$(builddir)/$(LIB_MAJOR_VERSION)) $(LBT_CFLAGS) $(SONAME_FLAG) $^ -shared $(LBT_LDFLAGS))
 
 $(builddir)/$(LIB_MAJOR_VERSION): | $(builddir)/$(LIB_FULL_VERSION)
 	ln -sf "$(LIB_FULL_VERSION)" "$@"
@@ -60,7 +60,7 @@ install: $(builddir)/libblastrampoline.$(SHLIB_EXT)
 	@cp -a $(builddir)/libblastrampoline*$(SHLIB_EXT)* $(DESTDIR)$(prefix)/$(binlib)/
 ifeq ($(OS),WINNT)
 	@mkdir -p $(DESTDIR)$(prefix)/lib
-	@cp -a $(builddir)/$(LIB_FULL_VERSION).a $(DESTDIR)$(prefix)/lib
+	@cp -a $(builddir)/$(LIB_MAJOR_VERSION).a $(DESTDIR)$(prefix)/lib
 endif
 
 clean:


### PR DESCRIPTION
Haven't tested (also because to test this I'd need to build a library linked to the new build of lbt), but I'm moderately confident this should solve #87, but as a side effect it'll break the ABI of the Windows library.  In addition we could remove `LIB_FULL_VERSION` for Windows, but that'd require more conditionals, I'm not sure this is worth the added complexity if we can fix the issue by adjusting the argument of `IMPLIB_FLAGS`.

Going forward, maintainers of lbt must remember to keep the soversion in `src/Make.inc` with the version of number of the package.