### PR TITLE
Eliminate `exit(1)` calls in LBT

### DIFF
--- a/src/autodetection.c
+++ b/src/autodetection.c
@@ -72,13 +72,19 @@ int32_t autodetect_blas_interface(void * isamax_addr) {
 
     // Override `lsame_` to point to our `fake_lsame` if we're unable to `RTLD_DEEPBIND`
     if (use_deepbind == 0) {
-        push_fake_lsame();
+        if (!push_fake_lsame()) {
+            // Bad LBT compile?
+            return LBT_INTERFACE_UNKNOWN;
+        }
     }
 
     int64_t max_idx = isamax(&n, X, &incx);
 
     if (use_deepbind == 0) {
-        pop_fake_lsame();
+        if (!pop_fake_lsame()) {
+            // Bad LBT compile?
+            return LBT_INTERFACE_UNKNOWN;
+        }
     }
 
     // Although we declare that `isamax` returns an `int64_t`, it may not actually do so,

--- a/src/dl_utils.c
+++ b/src/dl_utils.c
@@ -31,7 +31,7 @@ void * load_library(const char * path) {
     wchar_t wpath[2*PATH_MAX + 1] = {0};
     if (!utf8_to_wchar(path, wpath, 2*PATH_MAX)) {
         fprintf(stderr, "ERROR: Unable to convert path %s to wide string!\n", path);
-        exit(1);
+        return NULL;
     }
     new_handle = (void *)LoadLibraryExW(wpath, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
 #else
@@ -106,14 +106,16 @@ const char * lookup_self_path()
 #if defined(_OS_WINDOWS_)
     if (!GetModuleFileNameA(GetModuleHandle(NULL), self_path, PATH_MAX)) {
         fprintf(stderr, "ERROR: GetModuleFileName() failed\n");
-        exit(1);
+        strcpy(self_path, "<unknown>");
+        return self_path;
     }
 #else
     // On all other platforms, use dladdr()
     Dl_info info;
     if (!dladdr(lookup_self_symbol("lbt_forward"), &info)) {
         fprintf(stderr, "ERROR: Unable to dladdr(\"lbt_forward\"): %s\n", dlerror());
-        exit(1);
+        strcpy(self_path, "<unknown>");
+        return self_path;
     }
     strcpy(self_path, info.dli_fname);
 #endif

--- a/src/libblastrampoline.c
+++ b/src/libblastrampoline.c
@@ -274,8 +274,8 @@ LBT_DLLEXPORT int32_t lbt_forward(const char * libname, int32_t clear, int32_t v
                     printf(" -> CBLAS not found\n");
                     break;
                 default:
-                    printf(" -> ERROR: CBLAS DETECTION FAILED UNEXPECTEDLY\n");
-                    exit(1);
+                    printf(" -> ERROR: Impossible CBLAS detection result: %d\n", cblas);
+                    cblas = LBT_CBLAS_UNKNOWN;
                     break;
             }
         }

--- a/src/libblastrampoline_internal.h
+++ b/src/libblastrampoline_internal.h
@@ -92,7 +92,7 @@ int32_t autodetect_cblas_divergence(void * handle, const char * suffix);
 #endif
 
 // Functions in deepbindless_surrogates.c
-void push_fake_lsame();
-void pop_fake_lsame();
+uint8_t push_fake_lsame();
+uint8_t pop_fake_lsame();
 int fake_lsame(char * ca, char * cb);
 extern uint8_t use_deepbind;


### PR DESCRIPTION
It is rather rude of us to call `exit(1)` in our code, no matter how rare it is.  Instead, we do our best to set ourselves into stable states when these situations (many of which should be impossible) occur.