### PR TITLE
win: fix "No rule to make target"

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -56,10 +56,10 @@ $(builddir)/$(LIB_MAJOR_VERSION): $(MAIN_OBJS)
 ifneq ($(OS),WINNT)
 $(builddir)/$(LIB_FULL_VERSION): | $(builddir)/$(LIB_MAJOR_VERSION)
 	ln -sf "$(LIB_MAJOR_VERSION)" "$@"
+endif
 
 $(builddir)/libblastrampoline.$(SHLIB_EXT): | $(builddir)/$(LIB_MAJOR_VERSION)
 	ln -sf "$(LIB_MAJOR_VERSION)" "$@"
-endif
 
 # Install both libraries and our headers
 install: $(TARGET_LIBRARIES)


### PR DESCRIPTION
We always need this target: `$(builddir)/libblastrampoline.$(SHLIB_EXT)`.

https://github.com/JuliaLinearAlgebra/libblastrampoline/blob/165da4cfc584613cbc56c25a69750b819dc30436/src/Makefile#L4-L5

----

Do we need a cirrus ci for windows ?
I would like to add one.
