### PR TITLE
Add fallback for when `LBT_DEFAULT_LIBS` is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Julia Packages that utilize libblastrampline to provide easy access to BLAS libr
 
 Build `libblastrampoline.so`, then link your BLAS-using library against it instead of `libblas.so`.
 When `libblastrampoline` is loaded, it will inspect the `LBT_DEFAULT_LIBS` environment variable and attempt to forward BLAS calls made to it on to that library (this can be a list of semicolon-separated libraries if your backing implementation is split across multiple libraries, such as in the case of separate `BLAS` and `LAPACK` libraries).
+If `LBT_DEFAULT_LIBS` is not set, then `libblastrampoline` will fall back to the definition of the `LBT_FALLBACK_LIBS` macro specified at compile time.
 At any time, you may call `lbt_forward(libname, clear, verbose)` to redirect forwarding to a new BLAS library.
 If you set `clear` to `1` it will clear out all previous mappings before setting new mappings, while if it is set to `0` it will leave symbols that do not exist within the given `libname` alone.
 This is used to implement layering of libraries, such as between a split BLAS and LAPACK library:

--- a/src/libblastrampoline.c
+++ b/src/libblastrampoline.c
@@ -445,6 +445,11 @@ __attribute__((constructor)) void init(void) {
 
     // LBT_DEFAULT_LIBS is a semicolon-separated list of paths that should be loaded as BLAS libraries
     const char * default_libs = getenv("LBT_DEFAULT_LIBS");
+#if defined(LBT_FALLBACK_LIBS)
+    if (default_libs == NULL) {
+        default_libs = LBT_FALLBACK_LIBS;
+    }
+#endif
     if (default_libs != NULL) {
         const char * curr_lib_start = default_libs;
         int clear = 1;


### PR DESCRIPTION
Adding a compile-time specified fallback makes it easier to use LBT as a
drop-in replacement for any given BLAS implementation. One simply needs
to add a definition for `LBT_FALLBACK_LIBS` to `CFLAGS` at build time to
specify the fallback.
