### PR TITLE
Add support for ILP64 Accelerate

### DIFF
--- a/src/Make.inc
+++ b/src/Make.inc
@@ -98,6 +98,11 @@ ifneq (,$(filter $(ARCH), x86_64 aarch64))
   COMPLEX_RETSTYLE_AUTODETECTION := 1
 endif
 
+# If we're on an apple platform, we need to support symbol name trimming
+ifeq ($(OS), Darwin)
+  LBT_CFLAGS += -DSYMBOL_TRIMMING
+  SYMBOL_TRIMMING := 1
+endif
 
 ifeq ($(VERBOSE),0)
 ENDCOLOR := "\033[0m"

--- a/src/autodetection.c
+++ b/src/autodetection.c
@@ -65,18 +65,16 @@ const char * autodetect_symbol_suffix(void * handle, const char * suffix_hint) {
         // First, search for LP64-mangling suffixes, so that when we are loading libs from an
         // CLI environment, (where suffix hints are not easy) we want to give the most stable
         // configuration by default.
-#if defined(_OS_DARWIN_) && defined(SYMBOL_TRIMMING)
-        // Apple Accelerate has an updated LAPACK interface, default to that.
-        // Note that we are making use of our symbol trimming support here to eliminate
-        // the F77 trailing underscore by starting the string with `\x1a`.
-        "\x1a$NEWLAPACK",
-#endif
         "", "_", "__",
 
         // Next, ILP64-mangling suffixes
 #if defined(_OS_DARWIN_) && defined(SYMBOL_TRIMMING)
         // Once again, search for Accelerate's non-pure-suffixed names
         "\x1a$NEWLAPACK$ILP64",
+        // Apple Accelerate has an updated LAPACK interface.
+        // Note that we are making use of our symbol trimming support here to eliminate
+        // the F77 trailing underscore by starting the string with `\x1a`.
+        "\x1a$NEWLAPACK",
 #endif
 
         // Next, search for ILP64-mangling suffixes

--- a/src/config.c
+++ b/src/config.c
@@ -21,6 +21,18 @@ LBT_DLLEXPORT const lbt_config_t * lbt_get_config() {
     lbt_config.build_flags |= LBT_BUILDFLAGS_F2C_CAPABLE;
 #endif
 
+#if defined(CBLAS_DIVERGENCE_AUTODETECTION)
+    lbt_config.build_flags |= LBT_BUILDFLAGS_CBLAS_DIVERGENCE;
+#endif
+
+#if defined(COMPLEX_RETSTYLE_AUTODETECTION)
+    lbt_config.build_flags |= LBT_BUILDFLAGS_COMPLEX_RETSTYLE;
+#endif
+
+#if defined(SYMBOL_TRIMMING)
+    lbt_config.build_flags |= LBT_BUILDFLAGS_SYMBOL_TRIMMING;
+#endif
+
     lbt_config.exported_symbols = (const char **)&exported_func_names[0];
     lbt_config.num_exported_symbols = NUM_EXPORTED_FUNCS;
 

--- a/src/libblastrampoline.h
+++ b/src/libblastrampoline.h
@@ -111,8 +111,11 @@ typedef struct {
 } lbt_config_t;
 
 // Possible values for `build_flags` in `lbt_config_t`
-#define LBT_BUILDFLAGS_DEEPBINDLESS     0x01
-#define LBT_BUILDFLAGS_F2C_CAPABLE      0x02
+#define LBT_BUILDFLAGS_DEEPBINDLESS         0x01
+#define LBT_BUILDFLAGS_F2C_CAPABLE          0x02
+#define LBT_BUILDFLAGS_CBLAS_DIVERGENCE     0x04
+#define LBT_BUILDFLAGS_COMPLEX_RETSTYLE     0x08
+#define LBT_BUILDFLAGS_SYMBOL_TRIMMING      0x10
 
 /*
  * Load the given `libname`, lookup all registered symbols within our configured list of exported

--- a/src/libblastrampoline_internal.h
+++ b/src/libblastrampoline_internal.h
@@ -76,6 +76,7 @@ const char * lookup_self_path();
 void close_library(void * handle);
 
 // Functions in `autodetection.c`
+void build_symbol_name(char * out, const char *symbol_name, const char *suffix);
 const char * autodetect_symbol_suffix(void * handle, const char * suffix_hint);
 int32_t autodetect_blas_interface(void * isamax_addr);
 int32_t autodetect_lapack_interface(void * dpotrf_addr);

--- a/src/threading.c
+++ b/src/threading.c
@@ -47,9 +47,11 @@ LBT_DLLEXPORT void lbt_register_thread_interface(const char * getter, const char
 /*
  * Returns the number of threads configured in all loaded libraries.
  * In the event of a mismatch, returns the largest value.
+ * If no BLAS libraries with a known threading interface are loaded,
+ * returns `1`.
  */
 LBT_DLLEXPORT int32_t lbt_get_num_threads() {
-    int32_t max_threads = 0;
+    int32_t max_threads = 1;
 
     const lbt_config_t * config = lbt_get_config();
     for (int lib_idx=0; config->loaded_libs[lib_idx] != NULL; ++lib_idx) {

--- a/src/threading.c
+++ b/src/threading.c
@@ -56,7 +56,7 @@ LBT_DLLEXPORT int32_t lbt_get_num_threads() {
         lbt_library_info_t * lib = config->loaded_libs[lib_idx];
         for (int symbol_idx=0; getter_names[symbol_idx] != NULL; ++symbol_idx) {
             char symbol_name[MAX_SYMBOL_LEN];
-            sprintf(symbol_name, "%s%s", getter_names[symbol_idx], lib->suffix);
+            build_symbol_name(symbol_name, getter_names[symbol_idx], lib->suffix);
             int (*fptr)() = lookup_symbol(lib->handle, symbol_name);
             if (fptr != NULL) {
                 int new_threads = fptr();
@@ -78,7 +78,7 @@ LBT_DLLEXPORT void lbt_set_num_threads(int32_t nthreads) {
         lbt_library_info_t * lib = config->loaded_libs[lib_idx];
         for (int symbol_idx=0; setter_names[symbol_idx] != NULL; ++symbol_idx) {
             char symbol_name[MAX_SYMBOL_LEN];
-            sprintf(symbol_name, "%s%s", setter_names[symbol_idx], lib->suffix);
+            build_symbol_name(symbol_name, setter_names[symbol_idx], lib->suffix);
             void (*fptr)(int) = lookup_symbol(lib->handle, symbol_name);
             if (fptr != NULL) {
                 fptr(nthreads);

--- a/test/dpstrf_test/Makefile
+++ b/test/dpstrf_test/Makefile
@@ -1,0 +1,15 @@
+include ../../src/Make.inc
+
+all: $(prefix)/dpstrf_test$(EXE)
+
+$(prefix):
+	@mkdir -p $@
+
+$(prefix)/dpstrf_test$(EXE): dpstrf_test.c | $(prefix)
+	@$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS)
+
+clean:
+	@rm -f $(prefix)/dpstrf_test$(EXE)
+
+run: $(prefix)/dpstrf_test$(EXE)
+	@$(prefix)/dpstrf_test$(EXE)

--- a/test/dpstrf_test/dpstrf_test.c
+++ b/test/dpstrf_test/dpstrf_test.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <stdint.h>
+
+#ifdef ILP64
+#define MANGLE(x) x##64_
+typedef int64_t blasint;
+#else
+#define MANGLE(x) x
+typedef int32_t blasint;
+#endif
+
+extern blasint MANGLE(dpstrf_)(char *, blasint *, double *, blasint *, blasint *, blasint *, double *, double*, blasint *);
+
+#define N 4
+int main()
+{
+    blasint pivot[N];
+    blasint info;
+    double A[N][N];
+    double work[2*N];
+    blasint order = N;
+    blasint rank = 0;
+    blasint lda = N;
+    blasint stride = 1;
+    double tol = 0.0;
+    
+
+    // Initialize `A` with known values (transposed into FORTRAN ordering)
+    A[0][0] =   3.4291134;  A[1][0] = -0.61112815; A[2][0] =  0.8155207;  A[3][0] = -0.9183448;
+    A[0][1] =  -0.61112815; A[1][1] =  3.1250076;  A[2][1] = -0.44400603; A[3][1] =  0.97749346;
+    A[0][2] =   0.8155207;  A[1][2] = -0.44400603; A[2][2] =  0.5413656;  A[3][2] =  0.53000593;
+    A[0][3] =  -0.9183448;  A[1][3] =  0.97749346; A[2][3] =  0.53000593; A[3][3] =  5.108155;
+
+    // find solution using LAPACK routine dpstrf, all the arguments have to
+    // be pointers and you have to add an underscore to the routine name
+
+    //  parameters in the order as they appear in the function call
+    //  order of matrix A, number of right hand sides (b), matrix A,
+    // leading dimension of A, array that records pivoting,
+    // result vector b on entry, x on exit, leading dimension of b
+    //  return value
+    MANGLE(dpstrf_)("U", &order, &A[0][0], &lda, &pivot[0], &rank, &tol, &work[0], &info);
+    if (info != 0) {
+        printf("ERROR: info == %ld!\n", info);
+        return 1;
+    }
+
+    // Print out diagonal of A
+    printf("diag(A):");
+    for (blasint j=0; j<N; j++) {
+        printf(" %8.4f", A[j][j]);
+    }
+    printf("\n");
+    return 0;
+}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -170,6 +170,19 @@ if dlopen_e(veclib_blas_path) != C_NULL
     @testset "LBT -> vecLib/libLAPACK" begin
         run_all_tests(blastrampoline_link_name(), [lbt_dir], :LP64, string(veclib_blas_path, ";", veclib_lapack_path), tests=[dgemm, sgesv, sdot, zdotc])
     end
+
+    veclib_lapack_handle = dlopen(veclib_lapack_path)
+    if dlsym_e(veclib_lapack_handle, "dpotrf\$NEWLAPACK\$ILP64") != C_NULL
+        @testset "LBT -> vecLib/libBLAS (ILP64)" begin
+            veclib_blas_path_ilp64 = "$(veclib_blas_path)!\x1a\$NEWLAPACK\$ILP64"
+            run_all_tests(blastrampoline_link_name(), [lbt_dir], :ILP64, veclib_blas_path_ilp64; tests=[dgemm, sdot, zdotc])
+        end
+
+        @testset "LBT -> vecLib/libLAPACK (ILP64)" begin
+            veclib_lapack_path_ilp64 = "$(veclib_lapack_path)!\x1a\$NEWLAPACK\$ILP64"
+            run_all_tests(blastrampoline_link_name(), [lbt_dir], :ILP64, veclib_lapack_path_ilp64; tests=[dgemm, sgesv, sdot, zdotc])
+        end
+    end
 end
 
 


### PR DESCRIPTION
The new Accelerate released in macOS v13.3 provides two new interfaces; an upgraded LAPACK for the LP64 interface, and an all-new ILP64 interface (that uses the same upgraded LAPACK).  These symbols are available from Accelerate with the suffix `$NEWLAPACK` and `$NEWLAPACK$ILP64`, respectively.

Unfortunately, this is not a "true" suffix, as Apple has decided to drop the trailing underscore from the typical F77 names, meaning that a symbol such as `dgemm_` gets mangled to `dgemm$NEWLAPACK`, whereas a CBLAS symbol such as `cblas_zdotc_sub` gets mangled to `cblas_zdotc_sub$NEWLAPACK`.  This means that we need to selectively erase the trailing underscore from some symbols when applying this Accelerate suffix.

To do this, we add a new feature, enabled by default only on Apple builds, called `SYMBOL_TRIMMING`, which allows a `suffix_hint` to contain the ASCII "substitution character" `0x1a` as the first character of the suffix hint to mean "remove a trailing underscore when applying this suffix".

To make dealing with suffix hints easier for command-line users, these suffix hints are available for use in `LBT_BACKING_LIBS` by listing libraries separated by suffix hints with an exclamation point,  e.g. `libname!suffix`.