### PR TITLE
Prevent setting infinite loopback forwards

### DIFF
--- a/src/libblastrampoline_trampdata.h
+++ b/src/libblastrampoline_trampdata.h
@@ -33,3 +33,19 @@ const void ** exported_func64_addrs[] = {
 };
 #undef XX
 #undef XX_64
+
+// Generate list of our own function addresses, so that we can filter
+// out libraries that link against us (such as LAPACK_jll) so that we
+// don't accidentally loop back to ourselves.
+#define XX(name)    NULL,
+#define XX_64(name) NULL,
+const void ** exported_func32[] = {
+    EXPORTED_FUNCS(XX)
+    NULL
+};
+const void ** exported_func64[] = {
+    EXPORTED_FUNCS(XX_64)
+    NULL
+};
+#undef XX
+#undef XX_64


### PR DESCRIPTION
Some libraries, such as `libLAPACK` re-export their imported symbols, presumably in an effort to make it easy for users to link against just `libLAPACK` and get the BLAS symbols for free.  However, when LAPACK_jll has linked against LBT as its backing BLAS library, we end up with an infinite loop, as LBT then sets its BLAS symbols to its own trampoline.

This commit adds a special-case to our forwarding logic which explicitly checks for such a loop, and silently refuses to perform such a forward. This has the happy effect of filtering out direct loops, and makes it much easier to mix and match libraries that themselves depend on LBT.