### PR TITLE
Support `libdir` and `includedir` variables

### DIFF
--- a/src/Make.inc
+++ b/src/Make.inc
@@ -118,6 +118,9 @@ endif
 prefix ?= prefix
 builddir ?= build
 
+libdir := $(prefix)/$(binlib)
+includedir := $(prefix)/include
+
 define newline # a literal \n
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -73,12 +73,12 @@ endif
 
 # Install both libraries and our headers
 install: $(TARGET_LIBRARIES)
-	@mkdir -p $(DESTDIR)/$(includedir)/libblastrampoline
-	-@cp -Ra $(LBT_ROOT)/include/* $(DESTDIR)/$(includedir)/libblastrampoline
-	@cp -a $(LBT_ROOT)/src/libblastrampoline.h $(DESTDIR)/$(includedir)/
-	@mkdir -p $(DESTDIR)/$(libdir)
+	@mkdir -p $(DESTDIR)$(includedir)/libblastrampoline
+	-@cp -Ra $(LBT_ROOT)/include/* $(DESTDIR)$(includedir)/libblastrampoline
+	@cp -a $(LBT_ROOT)/src/libblastrampoline.h $(DESTDIR)$(includedir)/
+	@mkdir -p $(DESTDIR)$(libdir)
 	@for lib in $(TARGET_LIBRARIES); do \
-		cp -a $${lib} $(DESTDIR)/$(libdir)/; \
+		cp -a $${lib} $(DESTDIR)$(libdir)/; \
 	done
 ifeq ($(OS),WINNT)
 	@mkdir -p $(DESTDIR)$(prefix)/lib

--- a/src/Makefile
+++ b/src/Makefile
@@ -73,12 +73,12 @@ endif
 
 # Install both libraries and our headers
 install: $(TARGET_LIBRARIES)
-	@mkdir -p $(DESTDIR)$(prefix)/include/libblastrampoline
-	-@cp -Ra $(LBT_ROOT)/include/* $(DESTDIR)$(prefix)/include/libblastrampoline
-	@cp -a $(LBT_ROOT)/src/libblastrampoline.h $(DESTDIR)$(prefix)/include/
-	@mkdir -p $(DESTDIR)$(prefix)/$(binlib)
+	@mkdir -p $(DESTDIR)/$(includedir)/libblastrampoline
+	-@cp -Ra $(LBT_ROOT)/include/* $(DESTDIR)/$(includedir)/libblastrampoline
+	@cp -a $(LBT_ROOT)/src/libblastrampoline.h $(DESTDIR)/$(includedir)/
+	@mkdir -p $(DESTDIR)/$(libdir)
 	@for lib in $(TARGET_LIBRARIES); do \
-		cp -a $${lib} $(DESTDIR)$(prefix)/$(binlib)/; \
+		cp -a $${lib} $(DESTDIR)/$(libdir)/; \
 	done
 ifeq ($(OS),WINNT)
 	@mkdir -p $(DESTDIR)$(prefix)/lib


### PR DESCRIPTION
These are the standard GNU make variables that distributions expect to be able to set
(https://www.gnu.org/prep/standards/html_node/Directory-Variables.html). Since Julia supports the same variables and passes them during the build, this ensures that libblastrampoline.so is installed to the right directory (in particular to usr/lib64 where appropriate).