### PR TITLE
Update ext/gensymbol

### DIFF
--- a/ext/gensymbol/README.md
+++ b/ext/gensymbol/README.md
@@ -1,4 +1,4 @@
 # gensymbol
 
-This uses [the `gensymbol` script from OpenBLAS](https://github.com/xianyi/OpenBLAS/blob/develop/exports/gensymbol.pl) to generate a list of BLAS/LAPACK symbols from first principles.
+This uses [the `gensymbol` script from OpenBLAS](https://github.com/xianyi/OpenBLAS/blob/develop/exports/gensymbol) to generate a list of BLAS/LAPACK symbols from first principles.
 To use this, run `./generate_func_list.sh` and it will automatically populate [the `src/exported_funcs.inc` file](../../src/exported_funcs.inc).

--- a/ext/gensymbol/generate_func_list.sh
+++ b/ext/gensymbol/generate_func_list.sh
@@ -20,10 +20,10 @@ BUILD_DOUBLE=1
 BUILD_COMPLEX=1
 BUILD_COMPLEX16=1
 
-perl ./gensymbol ${SYS} ${ARCH} ${BU} ${EXPRECISION} \
-                 ${NO_CBLAS} ${NO_LAPACK} ${NO_LAPACKE} ${NEED2UNDERSCORES} \
-                 ${ONLY_CBLAS} "" "" \
-                 ${BUILD_LAPACK_DEPRECATED} ${BUILD_BFLOAT16} ${BUILD_SINGLE} ${BUILD_DOUBLE} ${BUILD_COMPLEX} ${BUILD_COMPLEX16} | LC_COLLATE=C sort > tempsymbols.def
+./gensymbol ${SYS} ${ARCH} ${BU} ${EXPRECISION} \
+            ${NO_CBLAS} ${NO_LAPACK} ${NO_LAPACKE} ${NEED2UNDERSCORES} \
+            ${ONLY_CBLAS} "" "" \
+            ${BUILD_LAPACK_DEPRECATED} ${BUILD_BFLOAT16} ${BUILD_SINGLE} ${BUILD_DOUBLE} ${BUILD_COMPLEX} ${BUILD_COMPLEX16} | LC_COLLATE=C sort > tempsymbols.def
 
 OUTPUT_FILE="${LBT_DIR}/src/exported_funcs.inc"
 echo -n "Outputting to ${OUTPUT_FILE}....."

--- a/ext/gensymbol/gensymbol
+++ b/ext/gensymbol/gensymbol
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/bin/sh
 
 # Changelog
 # 2017/09/03 staticfloat
@@ -16,3918 +16,4142 @@
 # 2017/08/01 Saar
 # removed blas_thread_shutdown_
 #
-@blasobjsc = (
-    caxpy,caxpby,ccopy,cdotc,cdotu,cgbmv,cgemm,cgemmt,cgemv,cgerc,cgeru,
-    chbmv,chemm,chemv,cher2,cher2k,cher,cherk,scabs1,scamax,
-    chpmv,chpr2,chpr,crotg,cscal,csrot,csscal,cswap,scamin,scasum,scnrm2,
-    csymm,csyr2k,csyrk,ctbmv,ctbsv,ctpmv,ctpsv,ctrmm,ctrmv,ctrsm,
-    ctrsv,icamax,icamin,cimatcopy,comatcopy,cgeadd,scsum);
-    
-@blasobjsd = (
-    damax,damin,dasum,daxpy,daxpby,dcabs1,dcopy,ddot,dgbmv,dgemm,dgemmt,
-    dgemv,dger,dmax,dmin,dnrm2,drot,drotg,drotm,drotmg,dsbmv,
-    dscal,dsdot,dspmv,dspr2,dimatcopy,domatcopy,
-    dspr,dswap,dsymm,dsymv,dsyr2,dsyr2k,dsyr,dsyrk,dtbmv,dtbsv,
-    dtpmv,dtpsv,dtrmm,dtrmv,dtrsm,dtrsv,
-        idamax,idamin,idmax,idmin,dgeadd,dsum);
-    
-@blasobjss = (
-    isamax,isamin,ismax,ismin,
-    samax,samin,sasum,saxpy, saxpby, 
-    scopy,sdot,sdsdot,sgbmv,sgemm,sgemmt,sgemv,sger,
-    smax,smin,snrm2,simatcopy,somatcopy,
-    srot,srotg,srotm,srotmg,ssbmv,sscal,sspmv,sspr2,sspr,sswap,
-    ssymm,ssymv,ssyr2,ssyr2k,ssyr,ssyrk,stbmv,stbsv,stpmv,stpsv,
-    strmm,strmv,strsm,strsv, sgeadd,ssum);
-     
-@blasobjsz = (
-    izamax,izamin,,
-    zaxpy,zaxpby,zcopy,zdotc,zdotu,zdrot,
-    zdscal,zgbmv,zgemm,zgemmt,zgemv,zgerc,zgeru,
-    zhbmv,zhemm,zhemv,zher2,zher2k,zher,zherk,zhpmv,zhpr2,
-    zhpr,zrotg,zscal,zswap,zsymm,zsyr2k,zsyrk,ztbmv,
-    ztbsv,ztpmv,ztpsv,ztrmm,ztrmv,ztrsm,ztrsv,
-    zomatcopy, zimatcopy,dzamax,dzamin,dzasum,dznrm2,
-    zgeadd, dzsum);
+blasobjsc="
+    caxpy caxpby ccopy cdotc cdotu cgbmv cgemm cgemv cgerc cgeru
+    chbmv chemm chemv cher2 cher2k cher cherk scabs1 scamax
+    chpmv chpr2 chpr crotg cscal csrot csscal cswap scamin scasum scnrm2
+    csymm csyr2k csyrk ctbmv ctbsv ctpmv ctpsv ctrmm ctrmv ctrsm
+    ctrsv icamax icamin cimatcopy comatcopy cgeadd scsum cgemmt"
 
-@blasobjs = (lsame, xerbla);
-@bfblasobjs = (sbgemm, sbgemv, sbdot, sbstobf16, sbdtobf16, sbf16tos, dbf16tod);
-@cblasobjsc = (
-    cblas_caxpy, cblas_ccopy, cblas_cdotc, cblas_cdotu, cblas_cgbmv, cblas_cgemm, cblas_cgemv,
-    cblas_cgerc, cblas_cgeru, cblas_chbmv, cblas_chemm, cblas_chemv, cblas_cher2, cblas_cher2k,
-    cblas_cher, cblas_cherk,  cblas_chpmv, cblas_chpr2, cblas_chpr, cblas_cscal, cblas_caxpby,
-    cblas_csscal, cblas_cswap, cblas_csymm, cblas_csyr2k, cblas_csyrk, cblas_ctbmv, cblas_cgeadd,
-    cblas_ctbsv, cblas_ctpmv, cblas_ctpsv, cblas_ctrmm, cblas_ctrmv, cblas_ctrsm, cblas_ctrsv, 
-    cblas_scnrm2, cblas_scasum,
-    cblas_icamax, cblas_icamin, cblas_icmin, cblas_icmax, cblas_scsum,cblas_cimatcopy,cblas_comatcopy
-    );
-@cblasobjsd = (
-    cblas_dasum, cblas_daxpy, cblas_dcopy, cblas_ddot,
-    cblas_dgbmv, cblas_dgemm, cblas_dgemv, cblas_dger, cblas_dnrm2,
-    cblas_drot, cblas_drotg, cblas_drotm, cblas_drotmg, cblas_dsbmv, cblas_dscal, cblas_dsdot,
-    cblas_dspmv, cblas_dspr2, cblas_dspr, cblas_dswap, cblas_dsymm, cblas_dsymv, cblas_dsyr2,
-    cblas_dsyr2k, cblas_dsyr, cblas_dsyrk, cblas_dtbmv, cblas_dtbsv, cblas_dtpmv, cblas_dtpsv,
-    cblas_dtrmm, cblas_dtrmv, cblas_dtrsm, cblas_dtrsv, cblas_daxpby, cblas_dgeadd,
-    cblas_idamax, cblas_idamin, cblas_idmin, cblas_idmax, cblas_dsum,cblas_dimatcopy,cblas_domatcopy
-    );
-    
-@cblasobjss = (
-    cblas_sasum, cblas_saxpy, cblas_saxpby,
-    cblas_scopy, cblas_sdot, cblas_sdsdot, cblas_sgbmv, cblas_sgemm,
-    cblas_sgemv, cblas_sger, cblas_snrm2, cblas_srot, cblas_srotg,
-    cblas_srotm, cblas_srotmg, cblas_ssbmv, cblas_sscal, cblas_sspmv, cblas_sspr2, cblas_sspr,
-    cblas_sswap, cblas_ssymm, cblas_ssymv, cblas_ssyr2, cblas_ssyr2k, cblas_ssyr, cblas_ssyrk,
-    cblas_stbmv, cblas_stbsv, cblas_stpmv, cblas_stpsv, cblas_strmm, cblas_strmv, cblas_strsm,
-    cblas_strsv, cblas_sgeadd,
-    cblas_isamax, cblas_isamin, cblas_ismin, cblas_ismax, cblas_ssum,cblas_simatcopy,cblas_somatcopy
-    );
-@cblasobjsz = (
-    cblas_dzasum, cblas_dznrm2, cblas_zaxpy, cblas_zcopy, cblas_zdotc, cblas_zdotu, cblas_zdscal,
-    cblas_zgbmv, cblas_zgemm, cblas_zgemv, cblas_zgerc, cblas_zgeru, cblas_zhbmv, cblas_zhemm,
-    cblas_zhemv, cblas_zher2, cblas_zher2k, cblas_zher, cblas_zherk, cblas_zhpmv, cblas_zhpr2,
-    cblas_zhpr, cblas_zscal, cblas_zswap, cblas_zsymm, cblas_zsyr2k, cblas_zsyrk,
-    cblas_ztbmv, cblas_ztbsv, cblas_ztpmv, cblas_ztpsv, cblas_ztrmm, cblas_ztrmv, cblas_ztrsm,
-    cblas_ztrsv, cblas_cdotc_sub, cblas_cdotu_sub, cblas_zdotc_sub, cblas_zdotu_sub,
-    cblas_zaxpby, cblas_zgeadd,
-    cblas_izamax, cblas_izamin, cblas_izmin, cblas_izmax, cblas_dzsum,cblas_zimatcopy,cblas_zomatcopy
-);
+blasobjsd="
+    damax damin dasum daxpy daxpby dcabs1 dcopy ddot dgbmv dgemm
+    dgemv dger dmax dmin dnrm2 drot drotg drotm drotmg dsbmv
+    dscal dsdot dspmv dspr2 dimatcopy domatcopy
+    dspr dswap dsymm dsymv dsyr2 dsyr2k dsyr dsyrk dtbmv dtbsv
+    dtpmv dtpsv dtrmm dtrmv dtrsm dtrsv
+        idamax idamin idmax idmin dgeadd dsum dgemmt"
 
-@cblasobjs = (  cblas_xerbla );
+blasobjss="
+    isamax isamin ismax ismin
+    samax samin sasum saxpy  saxpby
+    scopy sdot sdsdot sgbmv sgemm sgemv sger
+    smax smin snrm2 simatcopy somatcopy
+    srot srotg srotm srotmg ssbmv sscal sspmv sspr2 sspr sswap
+    ssymm ssymv ssyr2 ssyr2k ssyr ssyrk stbmv stbsv stpmv stpsv
+    strmm strmv strsm strsv  sgeadd ssum sgemmt"
 
-@bfcblasobjs = (cblas_sbgemm, cblas_sbgemv, cblas_sbdot, cblas_sbstobf16, cblas_sbdtobf16, cblas_sbf16tos, cblas_dbf16tod);
+blasobjsz="
+    izamax izamin
+    zaxpy zaxpby zcopy zdotc zdotu zdrot
+    zdscal zgbmv zgemm zgemv zgerc zgeru
+    zhbmv zhemm zhemv zher2 zher2k zher zherk zhpmv zhpr2
+    zhpr zrotg zscal zswap zsymm zsyr2k zsyrk ztbmv
+    ztbsv ztpmv ztpsv ztrmm ztrmv ztrsm ztrsv
+    zomatcopy  zimatcopy dzamax dzamin dzasum dznrm2
+    zgeadd  dzsum zgemmt"
 
-@exblasobjs = (
-    qamax,qamin,qasum,qaxpy,qcabs1,qcopy,qdot,qgbmv,qgemm,
-    qgemv,qger,qmax,qmin,
-    qnrm2,
-    qsbmv,qscal,qspmv,qspr2,
-    qspr,qswap,qsymm,qsymv,qsyr2,qsyr2k,qsyr,qsyrk,qtbmv,qtbsv,
-    qtpmv,qtpsv,qtrmm,qtrmv,qtrsm,qtrsv,
-    qxamax,qxamin,qxasum,qxnrm2,
-    xaxpy,xcopy,xdotc,xdotu,
-    xqscal,xgbmv,xgemm,xgemv,xgerc,xgeru,
-    xhbmv,xhemm,xhemv,xher2,xher2k,xher,xherk,xhpmv,xhpr2,
-    xhpr,xscal,xswap,xsymm,xsyr2k,xsyrk,xtbmv,
-    xtbsv,xtpmv,xtpsv,xtrmm,xtrmv,xtrsm,xtrsv,
-#	     qrot,qrotg,qrotm,qrotmg,
-#	     xdrot,xrotg,
-);
+blasobjs="lsame xerbla"
+bfblasobjs="sbgemm sbgemv sbdot sbstobf16 sbdtobf16 sbf16tos dbf16tod"
+cblasobjsc="
+    cblas_caxpy cblas_ccopy cblas_cdotc cblas_cdotu cblas_cgbmv cblas_cgemm cblas_cgemv
+    cblas_cgerc cblas_cgeru cblas_chbmv cblas_chemm cblas_chemv cblas_cher2 cblas_cher2k
+    cblas_cher cblas_cherk  cblas_chpmv cblas_chpr2 cblas_chpr cblas_cscal cblas_caxpby
+    cblas_csscal cblas_cswap cblas_csymm cblas_csyr2k cblas_csyrk cblas_ctbmv cblas_cgeadd
+    cblas_ctbsv cblas_ctpmv cblas_ctpsv cblas_ctrmm cblas_ctrmv cblas_ctrsm cblas_ctrsv
+    cblas_scnrm2 cblas_scasum cblas_cgemmt
+    cblas_icamax cblas_icamin cblas_icmin cblas_icmax cblas_scsum cblas_cimatcopy cblas_comatcopy
+    cblas_caxpyc cblas_crotg cblas_csrot cblas_scamax cblas_scamin
+    "
+cblasobjsd="
+    cblas_dasum cblas_daxpy cblas_dcopy cblas_ddot
+    cblas_dgbmv cblas_dgemm cblas_dgemv cblas_dger cblas_dnrm2
+    cblas_drot cblas_drotg cblas_drotm cblas_drotmg cblas_dsbmv cblas_dscal cblas_dsdot
+    cblas_dspmv cblas_dspr2 cblas_dspr cblas_dswap cblas_dsymm cblas_dsymv cblas_dsyr2
+    cblas_dsyr2k cblas_dsyr cblas_dsyrk cblas_dtbmv cblas_dtbsv cblas_dtpmv cblas_dtpsv
+    cblas_dtrmm cblas_dtrmv cblas_dtrsm cblas_dtrsv cblas_daxpby cblas_dgeadd cblas_dgemmt
+    cblas_idamax cblas_idamin cblas_idmin cblas_idmax cblas_dsum cblas_dimatcopy cblas_domatcopy
+    cblas_damax  cblas_damin
+    "
 
-    @gemm3mobjs=();
+cblasobjss="
+    cblas_sasum cblas_saxpy cblas_saxpby
+    cblas_scopy cblas_sdot cblas_sdsdot cblas_sgbmv cblas_sgemm
+    cblas_sgemv cblas_sger cblas_snrm2 cblas_srot cblas_srotg
+    cblas_srotm cblas_srotmg cblas_ssbmv cblas_sscal cblas_sspmv cblas_sspr2 cblas_sspr
+    cblas_sswap cblas_ssymm cblas_ssymv cblas_ssyr2 cblas_ssyr2k cblas_ssyr cblas_ssyrk
+    cblas_stbmv cblas_stbsv cblas_stpmv cblas_stpsv cblas_strmm cblas_strmv cblas_strsm
+    cblas_strsv cblas_sgeadd cblas_sgemmt
+    cblas_isamax cblas_isamin cblas_ismin cblas_ismax cblas_ssum cblas_simatcopy cblas_somatcopy
+    cblas_samax cblas_samin
+    "
 
-    @cblasgemm3mobjs=();
+cblasobjsz="
+    cblas_dzasum cblas_dznrm2 cblas_zaxpy cblas_zcopy cblas_zdotc cblas_zdotu cblas_zdscal
+    cblas_zgbmv cblas_zgemm cblas_zgemv cblas_zgerc cblas_zgeru cblas_zhbmv cblas_zhemm
+    cblas_zhemv cblas_zher2 cblas_zher2k cblas_zher cblas_zherk cblas_zhpmv cblas_zhpr2
+    cblas_zhpr cblas_zscal cblas_zswap cblas_zsymm cblas_zsyr2k cblas_zsyrk
+    cblas_ztbmv cblas_ztbsv cblas_ztpmv cblas_ztpsv cblas_ztrmm cblas_ztrmv cblas_ztrsm
+    cblas_ztrsv cblas_cdotc_sub cblas_cdotu_sub cblas_zdotc_sub cblas_zdotu_sub
+    cblas_zaxpby cblas_zgeadd cblas_zgemmt
+    cblas_izamax cblas_izamin cblas_izmin cblas_izmax cblas_dzsum cblas_zimatcopy cblas_zomatcopy
+    cblas_zaxpyc cblas_zdrot cblas_zrotg cblas_dzamax cblas_dzamin
+"
 
-@gemm3mobjsc = (
-    cgemm3m,
-);
-@gemm3mobjsz = (    
+cblasobjs="cblas_xerbla"
+
+bfcblasobjs="cblas_sbgemm cblas_sbgemv cblas_sbdot cblas_sbstobf16 cblas_sbdtobf16 cblas_sbf16tos cblas_dbf16tod"
+
+exblasobjs="
+    qamax qamin qasum qaxpy qcabs1 qcopy qdot qgbmv qgemm
+    qgemv qger qmax qmin
+    qnrm2
+    qsbmv qscal qspmv qspr2
+    qspr qswap qsymm qsymv qsyr2 qsyr2k qsyr qsyrk qtbmv qtbsv
+    qtpmv qtpsv qtrmm qtrmv qtrsm qtrsv
+    qxamax qxamin qxasum qxnrm2
+    xaxpy xcopy xdotc xdotu
+    xqscal xgbmv xgemm xgemv xgerc xgeru
+    xhbmv xhemm xhemv xher2 xher2k xher xherk xhpmv xhpr2
+    xhpr xscal xswap xsymm xsyr2k xsyrk xtbmv
+    xtbsv xtpmv xtpsv xtrmm xtrmv xtrsm xtrsv
+"
+#   qrot,qrotg,qrotm,qrotmg,
+#   xdrot,xrotg,
+
+gemm3mobj=""
+
+cblasgemm3mobj=""
+
+gemm3mobjsc="
+    cgemm3m
+"
+gemm3mobjsz="
     zgemm3m
-);
+"
 
-@cblasgemm3mobjsc = (
+cblasgemm3mobjsc="
     cblas_cgemm3m
-);
-@cblasgemm3mobjsz = (
+"
+cblasgemm3mobjsz="
     cblas_zgemm3m
-);
+"
 
 
 
 
 #both underscore and no underscore
-@misc_common_objs = (
-    openblas_get_parallel,
-    openblas_get_num_procs,
-    openblas_set_num_threads,
-    openblas_get_num_threads,
-);
+misc_common_objs="
+    openblas_get_parallel
+    openblas_get_num_procs
+    openblas_set_num_threads
+    openblas_get_num_threads
+"
 
-@misc_no_underscore_objs = (
-    goto_set_num_threads,
-    openblas_get_config,
-    openblas_get_corename,
-);
+misc_no_underscore_objs="
+    goto_set_num_threads
+    openblas_get_config
+    openblas_get_corename
+"
 
-@misc_underscore_objs = (
-);
+misc_underscore_objs=""
 
-@lapackobjss = (
-    # These routines are provided by OpenBLAS.
-    sgesv, 
-    sgetf2,
-    sgetrf,
-    slaswp,
-    sgetrs,
-    slauu2,
-    slauum,
-    spotf2,
-    spotrf,
-    strti2,
-    strtri,
-    spotri,
-);
+# These routines are provided by OpenBLAS.
+lapackobjss="
+    sgesv
+    sgetf2
+    sgetrf
+    slaswp
+    sgetrs
+    slauu2
+    slauum
+    spotf2
+    spotrf
+    strti2
+    strtri
+    spotri
+"
 
-@lapackobjsd = (
- dgesv,  
- dgetf2, 
- dgetrf, 
- dlaswp, 
- dgetrs, 
- dlauu2, 
- dlauum, 
- dpotf2, 
- dpotrf, 
- dtrti2, 
- dtrtri, 
- dpotri, 
-);
+lapackobjsd="
+ dgesv
+ dgetf2
+ dgetrf
+ dlaswp
+ dgetrs
+ dlauu2
+ dlauum
+ dpotf2
+ dpotrf
+ dtrti2
+ dtrtri
+ dpotri
+"
 
-@lapackobjsc = (
-cgesv,  
-cgetf2, 
-cgetrf, 
-claswp, 
-cgetrs, 
-clauu2, 
-clauum, 
-cpotf2, 
-cpotrf, 
-ctrti2, 
-ctrtri, 
-cpotri, 
-);
+lapackobjsc="
+cgesv
+cgetf2
+cgetrf
+claswp
+cgetrs
+clauu2
+clauum
+cpotf2
+cpotrf
+ctrti2
+ctrtri
+cpotri
+"
 
-@lapackobjsz = (
-zgesv,
-zgetf2,
-zgetrf,
-zlaswp,
-zgetrs,
-zlauu2,
-zlauum,
-zpotf2,
-zpotrf,
-ztrti2,
-ztrtri,
-zpotri,
-);
+lapackobjsz="
+zgesv
+zgetf2
+zgetrf
+zlaswp
+zgetrs
+zlauu2
+zlauum
+zpotf2
+zpotrf
+ztrti2
+ztrtri
+zpotri
+"
 
 
-@lapackobjs2 = (
-    # These routines are provided by LAPACK (reference implementation).
-    #
-    # This list is prepared by copying all routines listed in
-    # `lapack-3.4.1/SRC/Makefile` and replacing the '.o' suffix with a comma.
-    # Thereafter the following routines should be removed:
-    # - those provided by OpenBLAS (see @lapackobjs)
-    # - extra precision routines (see @lapack_extendedprecision_objs)
-    # Each of these have been marked individually with "already provided" or "excluded".
+# These routines are provided by LAPACK (reference implementation).
+#
+# This list is prepared by copying all routines listed in
+# `lapack-3.4.1/SRC/Makefile` and replacing the '.o' suffix with a comma.
+# Thereafter the following routines should be removed:
+# - those provided by OpenBLAS (see @lapackobjs)
+# - extra precision routines (see @lapack_extendedprecision_objs)
+# Each of these have been marked individually with "already provided" or "excluded".
 
-    # ALLAUX  -- Auxiliary routines called from all precisions
-    # already provided by @blasobjs: xerbla, lsame
-    ilaenv, ieeeck, lsamen,  iparmq,
-    ilaprec, ilatrans, ilauplo, iladiag,
-    ilaver, slamch, slamc3,
-);
+# ALLAUX  -- Auxiliary routines called from all precisions
+# already provided by b"asobjs: xerbla lsame
+lapackobjs2="
+    ilaenv ieeeck lsamen  iparmq
+    ilaprec ilatrans ilauplo iladiag
+    ilaver slamch slamc3
+"
 
-@lapackobjs2sc = (    
-    # SCLAUX  -- Auxiliary routines called from both REAL and COMPLEX.
-    # excluded: second_$(TIMER)
-    sbdsdc,
-    sbdsqr, sdisna, slabad, slacpy, sladiv, slae2,  slaebz,
-    slaed0, slaed1, slaed2, slaed3, slaed4, slaed5, slaed6,
-    slaed7, slaed8, slaed9, slaeda, slaev2, slagtf,
-    slagts, slamrg, slanst,
-    slapy2, slapy3, slarnv,
-    slarra, slarrb, slarrc, slarrd, slarre, slarrf, slarrj,
-    slarrk, slarrr, slaneg,
-    slartg, slaruv, slas2,  slascl,
-    slasd0, slasd1, slasd2, slasd3, slasd4, slasd5, slasd6,
-    slasd7, slasd8, slasda, slasdq, slasdt,
-    slaset, slasq1, slasq2, slasq3, slasq4, slasq5, slasq6,
-    slasr,  slasrt, slassq, slasv2, spttrf, sstebz, sstedc,
-    ssteqr, ssterf, slaisnan, sisnan,
-    slartgp, slartgs,
-);
+# SCLAUX  -- Auxiliary routines called from both REAL and COMPLEX.
+# excluded: second_$(TIMER)
+lapackobjs2sc="
+    sbdsdc
+    sbdsqr sdisna slabad slacpy sladiv slae2  slaebz
+    slaed0 slaed1 slaed2 slaed3 slaed4 slaed5 slaed6
+    slaed7 slaed8 slaed9 slaeda slaev2 slagtf
+    slagts slamrg slanst
+    slapy2 slapy3 slarnv
+    slarra slarrb slarrc slarrd slarre slarrf slarrj
+    slarrk slarrr slaneg
+    slartg slaruv slas2  slascl
+    slasd0 slasd1 slasd2 slasd3 slasd4 slasd5 slasd6
+    slasd7 slasd8 slasda slasdq slasdt
+    slaset slasq1 slasq2 slasq3 slasq4 slasq5 slasq6
+    slasr  slasrt slassq slasv2 spttrf sstebz sstedc
+    ssteqr ssterf slaisnan sisnan
+    slartgp slartgs
+"
 
-@lapackobjs2dz = (
-    # DZLAUX  -- Auxiliary routines called from both DOUBLE and COMPLEX*16.
-    # excluded: dsecnd_$(TIMER)
-    dbdsdc,
-    dbdsqr, ddisna, dlabad, dlacpy, dladiv, dlae2,  dlaebz,
-    dlaed0, dlaed1, dlaed2, dlaed3, dlaed4, dlaed5, dlaed6,
-    dlaed7, dlaed8, dlaed9, dlaeda, dlaev2, dlagtf,
-    dlagts, dlamrg, dlanst,
-    dlapy2, dlapy3, dlarnv,
-    dlarra, dlarrb, dlarrc, dlarrd, dlarre, dlarrf, dlarrj,
-    dlarrk, dlarrr, dlaneg,
-    dlartg, dlaruv, dlas2,  dlascl,
-    dlasd0, dlasd1, dlasd2, dlasd3, dlasd4, dlasd5, dlasd6,
-    dlasd7, dlasd8, dlasda, dlasdq, dlasdt,
-    dlaset, dlasq1, dlasq2, dlasq3, dlasq4, dlasq5, dlasq6,
-    dlasr,  dlasrt, dlassq, dlasv2, dpttrf, dstebz, dstedc,
-    dsteqr, dsterf, dlaisnan, disnan,
-    dlartgp, dlartgs,
-    dlamch, dlamc3,
-);
+# DZLAUX  -- Auxiliary routines called from both DOUBLE and COMPLEX*16.
+# excluded: dsecnd_$(TIMER)
+lapackobjs2dz="
+    dbdsdc
+    dbdsqr ddisna dlabad dlacpy dladiv dlae2  dlaebz
+    dlaed0 dlaed1 dlaed2 dlaed3 dlaed4 dlaed5 dlaed6
+    dlaed7 dlaed8 dlaed9 dlaeda dlaev2 dlagtf
+    dlagts dlamrg dlanst
+    dlapy2 dlapy3 dlarnv
+    dlarra dlarrb dlarrc dlarrd dlarre dlarrf dlarrj
+    dlarrk dlarrr dlaneg
+    dlartg dlaruv dlas2  dlascl
+    dlasd0 dlasd1 dlasd2 dlasd3 dlasd4 dlasd5 dlasd6
+    dlasd7 dlasd8 dlasda dlasdq dlasdt
+    dlaset dlasq1 dlasq2 dlasq3 dlasq4 dlasq5 dlasq6
+    dlasr  dlasrt dlassq dlasv2 dpttrf dstebz dstedc
+    dsteqr dsterf dlaisnan disnan
+    dlartgp dlartgs
+    dlamch dlamc3
+"
 
-@lapackobjs2s = (
-    # SLASRC  -- Single precision real LAPACK routines
-    # already provided by @lapackobjs:
-    #     sgesv, sgetf2, slaswp, slauu2, slauum, spotf2, spotri, strti2, strtri
-    sgbbrd, sgbcon, sgbequ, sgbrfs, sgbsv,
-    sgbsvx, sgbtf2, sgbtrf, sgbtrs, sgebak, sgebal, sgebd2,
-    sgebrd, sgecon, sgeequ, sgees,  sgeesx, sgeev,  sgeevx,
-    sgehd2, sgehrd, sgelq2, sgelqf,
-    sgels,  sgelsd, sgelss, sgelsy, sgeql2, sgeqlf,
-    sgeqp3, sgeqr2, sgeqr2p, sgeqrf, sgeqrfp, sgerfs,
-    sgerq2, sgerqf, sgesc2, sgesdd, sgesvd, sgesvx,
-    sgetc2, sgetri,
-    sggbak, sggbal, sgges,  sggesx, sggev,  sggevx,
-    sggglm, sgghrd, sgglse, sggqrf,
-    sggrqf, sgtcon, sgtrfs, sgtsv,
-    sgtsvx, sgttrf, sgttrs, sgtts2, shgeqz,
-    shsein, shseqr, slabrd, slacon, slacn2,
-    slaein, slaexc, slag2,  slags2, slagtm, slagv2, slahqr,
-    slahr2, slaic1, slaln2, slals0, slalsa, slalsd,
-    slangb, slange, slangt, slanhs, slansb, slansp,
-    slansy, slantb, slantp, slantr, slanv2,
-    slapll, slapmt,
-    slaqgb, slaqge, slaqp2, slaqps, slaqsb, slaqsp, slaqsy,
-    slaqr0, slaqr1, slaqr2, slaqr3, slaqr4, slaqr5,
-    slaqtr, slar1v, slar2v, ilaslr, ilaslc,
-    slarf,  slarfb, slarfg, slarfgp, slarft, slarfx, slargv,
-    slarrv, slartv,
-    slarz,  slarzb, slarzt, slasy2, slasyf,
-    slatbs, slatdf, slatps, slatrd, slatrs, slatrz,
-    sopgtr, sopmtr, sorg2l, sorg2r,
-    sorgbr, sorghr, sorgl2, sorglq, sorgql, sorgqr, sorgr2,
-    sorgrq, sorgtr, sorm2l, sorm2r,
-    sormbr, sormhr, sorml2, sormlq, sormql, sormqr, sormr2,
-    sormr3, sormrq, sormrz, sormtr, spbcon, spbequ, spbrfs,
-    spbstf, spbsv,  spbsvx,
-    spbtf2, spbtrf, spbtrs, spocon, spoequ, sporfs, sposv,
-    sposvx, spstrf, spstf2,
-    sppcon, sppequ,
-    spprfs, sppsv,  sppsvx, spptrf, spptri, spptrs, sptcon,
-    spteqr, sptrfs, sptsv,  sptsvx, spttrs, sptts2, srscl,
-    ssbev,  ssbevd, ssbevx, ssbgst, ssbgv,  ssbgvd, ssbgvx,
-    ssbtrd, sspcon, sspev,  sspevd, sspevx, sspgst,
-    sspgv,  sspgvd, sspgvx, ssprfs, sspsv,  sspsvx, ssptrd,
-    ssptrf, ssptri, ssptrs, sstegr, sstein, sstev,  sstevd, sstevr,
-    sstevx,
-    ssycon, ssyev,  ssyevd, ssyevr, ssyevx, ssygs2,
-    ssygst, ssygv,  ssygvd, ssygvx, ssyrfs, ssysv,  ssysvx,
-    ssytd2, ssytf2, ssytrd, ssytrf, ssytri, ssytri2, ssytri2x,
-    ssyswapr, ssytrs, ssytrs2, ssyconv,
-    stbcon,
-    stbrfs, stbtrs, stgevc, stgex2, stgexc, stgsen,
-    stgsja, stgsna, stgsy2, stgsyl, stpcon, stprfs, stptri,
-    stptrs,
-    strcon, strevc, strexc, strrfs, strsen, strsna, strsyl,
-    strtrs, stzrzf, sstemr,
-    slansf, spftrf, spftri, spftrs, ssfrk, stfsm, stftri, stfttp,
-    stfttr, stpttf, stpttr, strttf, strttp,
-    sgejsv,  sgesvj,  sgsvj0,  sgsvj1,
-    sgeequb, ssyequb, spoequb, sgbequb,
-    sbbcsd, slapmr, sorbdb, sorbdb1, sorbdb2, sorbdb3, sorbdb4,
-    sorbdb5, sorbdb6, sorcsd, sorcsd2by1,
-    sgeqrt, sgeqrt2, sgeqrt3, sgemqrt,
-    stpqrt, stpqrt2, stpmqrt, stprfb,
-);
+# SLASRC  -- Single precision real LAPACK routines
+# already provided by l"packobjs:
+#     sgesv sgetf2 slaswp slauu2 slauum spotf2 spotri strti2 strtri
+lapackobjs2s="
+    sgbbrd sgbcon sgbequ sgbrfs sgbsv
+    sgbsvx sgbtf2 sgbtrf sgbtrs sgebak sgebal sgebd2
+    sgebrd sgecon sgeequ sgees  sgeesx sgeev  sgeevx
+    sgehd2 sgehrd sgelq2 sgelqf
+    sgels  sgelsd sgelss sgelsy sgeql2 sgeqlf
+    sgeqp3 sgeqr2 sgeqr2p sgeqrf sgeqrfp sgerfs
+    sgerq2 sgerqf sgesc2 sgesdd sgesvd sgesvx
+    sgetc2 sgetri
+    sggbak sggbal sgges  sggesx sggev  sggevx
+    sggglm sgghrd sgglse sggqrf
+    sggrqf sgtcon sgtrfs sgtsv
+    sgtsvx sgttrf sgttrs sgtts2 shgeqz
+    shsein shseqr slabrd slacon slacn2
+    slaein slaexc slag2  slags2 slagtm slagv2 slahqr
+    slahr2 slaic1 slaln2 slals0 slalsa slalsd
+    slangb slange slangt slanhs slansb slansp
+    slansy slantb slantp slantr slanv2
+    slapll slapmt
+    slaqgb slaqge slaqp2 slaqps slaqsb slaqsp slaqsy
+    slaqr0 slaqr1 slaqr2 slaqr3 slaqr4 slaqr5
+    slaqtr slar1v slar2v ilaslr ilaslc
+    slarf  slarfb slarfg slarfgp slarft slarfx slargv
+    slarrv slartv
+    slarz  slarzb slarzt slasy2 slasyf
+    slatbs slatdf slatps slatrd slatrs slatrz
+    sopgtr sopmtr sorg2l sorg2r
+    sorgbr sorghr sorgl2 sorglq sorgql sorgqr sorgr2
+    sorgrq sorgtr sorm2l sorm2r
+    sormbr sormhr sorml2 sormlq sormql sormqr sormr2
+    sormr3 sormrq sormrz sormtr spbcon spbequ spbrfs
+    spbstf spbsv  spbsvx
+    spbtf2 spbtrf spbtrs spocon spoequ sporfs sposv
+    sposvx spstrf spstf2
+    sppcon sppequ
+    spprfs sppsv  sppsvx spptrf spptri spptrs sptcon
+    spteqr sptrfs sptsv  sptsvx spttrs sptts2 srscl
+    ssbev  ssbevd ssbevx ssbgst ssbgv  ssbgvd ssbgvx
+    ssbtrd sspcon sspev  sspevd sspevx sspgst
+    sspgv  sspgvd sspgvx ssprfs sspsv  sspsvx ssptrd
+    ssptrf ssptri ssptrs sstegr sstein sstev  sstevd sstevr
+    sstevx
+    ssycon ssyev  ssyevd ssyevr ssyevx ssygs2
+    ssygst ssygv  ssygvd ssygvx ssyrfs ssysv  ssysvx
+    ssytd2 ssytf2 ssytrd ssytrf ssytri ssytri2 ssytri2x
+    ssyswapr ssytrs ssytrs2 ssyconv
+    stbcon
+    stbrfs stbtrs stgevc stgex2 stgexc stgsen
+    stgsja stgsna stgsy2 stgsyl stpcon stprfs stptri
+    stptrs
+    strcon strevc strexc strrfs strsen strsna strsyl
+    strtrs stzrzf sstemr
+    slansf spftrf spftri spftrs ssfrk stfsm stftri stfttp
+    stfttr stpttf stpttr strttf strttp
+    sgejsv  sgesvj  sgsvj0  sgsvj1
+    sgeequb ssyequb spoequb sgbequb
+    sbbcsd slapmr sorbdb sorbdb1 sorbdb2 sorbdb3 sorbdb4
+    sorbdb5 sorbdb6 sorcsd sorcsd2by1
+    sgeqrt sgeqrt2 sgeqrt3 sgemqrt
+    stpqrt stpqrt2 stpmqrt stprfb
+"
 
-@lapackobjs2ds = (
-    # DSLASRC -- Double-single mixed precision real routines called from
-    # single, single-extra and double precision real LAPACK
-    # routines (i.e. from SLASRC, SXLASRC, DLASRC).
-    #
-    # already provided by @lapackobjs:
-    #     sgetrs, spotrf, sgetrf
-    spotrs,
-);
+# DSLASRC -- Double-single mixed precision real routines called from
+# single, single-extra and double precision real LAPACK
+# routines (i.e. from SLASRC, SXLASRC, DLASRC).
+#
+# already provided by @lapackobjs:
+#     sgetrs, spotrf, sgetrf
+lapackobjs2ds="
+    spotrs
+"
 
-@lapackobjs2c = (
-    # CLASRC  -- Single precision complex LAPACK routines
-    # already provided by @blasobjs:
-    # already provided by @lapackobjs:
-    #     cgesv, cgetf2, claswp, clauu2, clauum, cpotf2, cpotri, ctrti2, ctrtri
-    cbdsqr, cgbbrd, cgbcon, cgbequ, cgbrfs, cgbsv,  cgbsvx,
-    cgbtf2, cgbtrf, cgbtrs, cgebak, cgebal, cgebd2, cgebrd,
-    cgecon, cgeequ, cgees,  cgeesx, cgeev,  cgeevx,
-    cgehd2, cgehrd, cgelq2, cgelqf,
-    cgels,  cgelsd, cgelss, cgelsy, cgeql2, cgeqlf, cgeqp3,
-    cgeqr2, cgeqr2p, cgeqrf, cgeqrfp, cgerfs,
-    cgerq2, cgerqf, cgesc2, cgesdd, cgesvd,
-    cgesvx, cgetc2, cgetri,
-    cggbak, cggbal, cgges,  cggesx, cggev,  cggevx, cggglm,
-    cgghrd, cgglse, cggqrf, cggrqf,
-    cgtcon, cgtrfs, cgtsv,  cgtsvx, cgttrf, cgttrs, cgtts2, chbev,
-    chbevd, chbevx, chbgst, chbgv,  chbgvd, chbgvx, chbtrd,
-    checon, cheev,  cheevd, cheevr, cheevx, chegs2, chegst,
-    chegv,  chegvd, chegvx, cherfs, chesv,  chesvx, chetd2,
-    chetf2, chetrd,
-    chetrf, chetri, chetri2, chetri2x, cheswapr,
-    chetrs, chetrs2, chgeqz, chpcon, chpev,  chpevd,
-    chpevx, chpgst, chpgv,  chpgvd, chpgvx, chprfs, chpsv,
-    chpsvx,
-    chptrd, chptrf, chptri, chptrs, chsein, chseqr, clabrd,
-    clacgv, clacon, clacn2, clacp2, clacpy, clacrm, clacrt, cladiv,
-    claed0, claed7, claed8,
-    claein, claesy, claev2, clags2, clagtm,
-    clahef, clahqr,
-    clahr2, claic1, clals0, clalsa, clalsd, clangb, clange, clangt,
-    clanhb, clanhe,
-    clanhp, clanhs, clanht, clansb, clansp, clansy, clantb,
-    clantp, clantr, clapll, clapmt, clarcm, claqgb, claqge,
-    claqhb, claqhe, claqhp, claqp2, claqps, claqsb,
-    claqr0, claqr1, claqr2, claqr3, claqr4, claqr5,
-    claqsp, claqsy, clar1v, clar2v, ilaclr, ilaclc,
-    clarf,  clarfb, clarfg, clarft, clarfgp,
-    clarfx, clargv, clarnv, clarrv, clartg, clartv,
-    clarz,  clarzb, clarzt, clascl, claset, clasr,  classq,
-    clasyf, clatbs, clatdf, clatps, clatrd, clatrs, clatrz,
-    cpbcon, cpbequ, cpbrfs, cpbstf, cpbsv,
-    cpbsvx, cpbtf2, cpbtrf, cpbtrs, cpocon, cpoequ, cporfs,
-    cposv,  cposvx, cpstrf, cpstf2,
-    cppcon, cppequ, cpprfs, cppsv,  cppsvx, cpptrf, cpptri, cpptrs,
-    cptcon, cpteqr, cptrfs, cptsv,  cptsvx, cpttrf, cpttrs, cptts2,
-    crot,   cspcon, cspmv,  cspr,   csprfs, cspsv,
-    cspsvx, csptrf, csptri, csptrs, csrscl, cstedc,
-    cstegr, cstein, csteqr,
-    csycon,
-    csymv,
-    csyr, csyrfs, csysv,  csysvx, csytf2, csytrf, csytri, csytri2, csytri2x,
-    csyswapr, csytrs, csytrs2, csyconv,
-    ctbcon, ctbrfs, ctbtrs, ctgevc, ctgex2,
-    ctgexc, ctgsen, ctgsja, ctgsna, ctgsy2, ctgsyl, ctpcon,
-    ctprfs, ctptri,
-    ctptrs, ctrcon, ctrevc, ctrexc, ctrrfs, ctrsen, ctrsna,
-    ctrsyl, ctrtrs, ctzrzf, cung2l, cung2r,
-    cungbr, cunghr, cungl2, cunglq, cungql, cungqr, cungr2,
-    cungrq, cungtr, cunm2l, cunm2r, cunmbr, cunmhr, cunml2,
-    cunmlq, cunmql, cunmqr, cunmr2, cunmr3, cunmrq, cunmrz,
-    cunmtr, cupgtr, cupmtr, icmax1, scsum1, cstemr,
-    chfrk, ctfttp, clanhf, cpftrf, cpftri, cpftrs, ctfsm, ctftri,
-    ctfttr, ctpttf, ctpttr, ctrttf, ctrttp,
-    cgeequb, cgbequb, csyequb, cpoequb, cheequb,
-    cbbcsd, clapmr, cunbdb, cunbdb1, cunbdb2, cunbdb3, cunbdb4,
-    cunbdb5, cunbdb6, cuncsd, cuncsd2by1,
-    cgeqrt, cgeqrt2, cgeqrt3, cgemqrt,
-    ctpqrt, ctpqrt2, ctpmqrt, ctprfb,
-);
-@lapackobjs2zc = (
-    # ZCLASRC -- Double-single mixed precision complex routines called from
-    # single, single-extra and double precision complex LAPACK
-    # routines (i.e. from CLASRC, CXLASRC, ZLASRC).
-    #
-    # already provided by @lapackobjs:
-    #     cgetrs, cpotrf, cgetrf
-    cpotrs,
-);
+# CLASRC  -- Single precision complex LAPACK routines
+# already provided by @blasobjs:
+# already provided by @lapackobjs:
+#     cgesv, cgetf2, claswp, clauu2, clauum, cpotf2, cpotri, ctrti2, ctrtri
+lapackobjs2c="
+    cbdsqr cgbbrd cgbcon cgbequ cgbrfs cgbsv  cgbsvx
+    cgbtf2 cgbtrf cgbtrs cgebak cgebal cgebd2 cgebrd
+    cgecon cgeequ cgees  cgeesx cgeev  cgeevx
+    cgehd2 cgehrd cgelq2 cgelqf
+    cgels  cgelsd cgelss cgelsy cgeql2 cgeqlf cgeqp3
+    cgeqr2 cgeqr2p cgeqrf cgeqrfp cgerfs
+    cgerq2 cgerqf cgesc2 cgesdd cgesvd
+    cgesvx cgetc2 cgetri
+    cggbak cggbal cgges  cggesx cggev  cggevx cggglm
+    cgghrd cgglse cggqrf cggrqf
+    cgtcon cgtrfs cgtsv  cgtsvx cgttrf cgttrs cgtts2 chbev
+    chbevd chbevx chbgst chbgv  chbgvd chbgvx chbtrd
+    checon cheev  cheevd cheevr cheevx chegs2 chegst
+    chegv  chegvd chegvx cherfs chesv  chesvx chetd2
+    chetf2 chetrd
+    chetrf chetri chetri2 chetri2x cheswapr
+    chetrs chetrs2 chgeqz chpcon chpev  chpevd
+    chpevx chpgst chpgv  chpgvd chpgvx chprfs chpsv
+    chpsvx
+    chptrd chptrf chptri chptrs chsein chseqr clabrd
+    clacgv clacon clacn2 clacp2 clacpy clacrm clacrt cladiv
+    claed0 claed7 claed8
+    claein claesy claev2 clags2 clagtm
+    clahef clahqr
+    clahr2 claic1 clals0 clalsa clalsd clangb clange clangt
+    clanhb clanhe
+    clanhp clanhs clanht clansb clansp clansy clantb
+    clantp clantr clapll clapmt clarcm claqgb claqge
+    claqhb claqhe claqhp claqp2 claqps claqsb
+    claqr0 claqr1 claqr2 claqr3 claqr4 claqr5
+    claqsp claqsy clar1v clar2v ilaclr ilaclc
+    clarf  clarfb clarfg clarft clarfgp
+    clarfx clargv clarnv clarrv clartg clartv
+    clarz  clarzb clarzt clascl claset clasr  classq
+    clasyf clatbs clatdf clatps clatrd clatrs clatrz
+    cpbcon cpbequ cpbrfs cpbstf cpbsv
+    cpbsvx cpbtf2 cpbtrf cpbtrs cpocon cpoequ cporfs
+    cposv  cposvx cpstrf cpstf2
+    cppcon cppequ cpprfs cppsv  cppsvx cpptrf cpptri cpptrs
+    cptcon cpteqr cptrfs cptsv  cptsvx cpttrf cpttrs cptts2
+    crot   cspcon cspmv  cspr   csprfs cspsv
+    cspsvx csptrf csptri csptrs csrscl cstedc
+    cstegr cstein csteqr
+    csycon
+    csymv
+    csyr csyrfs csysv  csysvx csytf2 csytrf csytri csytri2 csytri2x
+    csyswapr csytrs csytrs2 csyconv
+    ctbcon ctbrfs ctbtrs ctgevc ctgex2
+    ctgexc ctgsen ctgsja ctgsna ctgsy2 ctgsyl ctpcon
+    ctprfs ctptri
+    ctptrs ctrcon ctrevc ctrexc ctrrfs ctrsen ctrsna
+    ctrsyl ctrtrs ctzrzf cung2l cung2r
+    cungbr cunghr cungl2 cunglq cungql cungqr cungr2
+    cungrq cungtr cunm2l cunm2r cunmbr cunmhr cunml2
+    cunmlq cunmql cunmqr cunmr2 cunmr3 cunmrq cunmrz
+    cunmtr cupgtr cupmtr icmax1 scsum1 cstemr
+    chfrk ctfttp clanhf cpftrf cpftri cpftrs ctfsm ctftri
+    ctfttr ctpttf ctpttr ctrttf ctrttp
+    cgeequb cgbequb csyequb cpoequb cheequb
+    cbbcsd clapmr cunbdb cunbdb1 cunbdb2 cunbdb3 cunbdb4
+    cunbdb5 cunbdb6 cuncsd cuncsd2by1
+    cgeqrt cgeqrt2 cgeqrt3 cgemqrt
+    ctpqrt ctpqrt2 ctpmqrt ctprfb
+"
 
-@lapackobjs2d = (
-    # DLASRC  -- Double precision real LAPACK routines
-    # already provided by @lapackobjs:
-    #     dgesv, dgetf2, dgetrs, dlaswp, dlauu2, dlauum, dpotf2, dpotrf, dpotri,
-    #     dtrti2, dtrtri
-    dgbbrd, dgbcon, dgbequ, dgbrfs, dgbsv,
-    dgbsvx, dgbtf2, dgbtrf, dgbtrs, dgebak, dgebal, dgebd2,
-    dgebrd, dgecon, dgeequ, dgees,  dgeesx, dgeev,  dgeevx,
-    dgehd2, dgehrd, dgelq2, dgelqf,
-    dgels,  dgelsd, dgelss, dgelsy, dgeql2, dgeqlf,
-    dgeqp3, dgeqr2, dgeqr2p, dgeqrf, dgeqrfp, dgerfs,
-    dgerq2, dgerqf, dgesc2, dgesdd, dgesvd, dgesvx,
-    dgetc2, dgetri,
-    dggbak, dggbal, dgges,  dggesx, dggev,  dggevx,
-    dggglm, dgghrd, dgglse, dggqrf,
-    dggrqf, dgtcon, dgtrfs, dgtsv,
-    dgtsvx, dgttrf, dgttrs, dgtts2, dhgeqz,
-    dhsein, dhseqr, dlabrd, dlacon, dlacn2,
-    dlaein, dlaexc, dlag2,  dlags2, dlagtm, dlagv2, dlahqr,
-    dlahr2, dlaic1, dlaln2, dlals0, dlalsa, dlalsd,
-    dlangb, dlange, dlangt, dlanhs, dlansb, dlansp,
-    dlansy, dlantb, dlantp, dlantr, dlanv2,
-    dlapll, dlapmt,
-    dlaqgb, dlaqge, dlaqp2, dlaqps, dlaqsb, dlaqsp, dlaqsy,
-    dlaqr0, dlaqr1, dlaqr2, dlaqr3, dlaqr4, dlaqr5,
-    dlaqtr, dlar1v, dlar2v, iladlr, iladlc,
-    dlarf,  dlarfb, dlarfg, dlarfgp, dlarft, dlarfx,
-    dlargv, dlarrv, dlartv,
-    dlarz,  dlarzb, dlarzt, dlasy2, dlasyf,
-    dlatbs, dlatdf, dlatps, dlatrd, dlatrs, dlatrz,
-    dopgtr, dopmtr, dorg2l, dorg2r,
-    dorgbr, dorghr, dorgl2, dorglq, dorgql, dorgqr, dorgr2,
-    dorgrq, dorgtr, dorm2l, dorm2r,
-    dormbr, dormhr, dorml2, dormlq, dormql, dormqr, dormr2,
-    dormr3, dormrq, dormrz, dormtr, dpbcon, dpbequ, dpbrfs,
-    dpbstf, dpbsv,  dpbsvx,
-    dpbtf2, dpbtrf, dpbtrs, dpocon, dpoequ, dporfs, dposv,
-    dposvx, dpotrs, dpstrf, dpstf2,
-    dppcon, dppequ,
-    dpprfs, dppsv,  dppsvx, dpptrf, dpptri, dpptrs, dptcon,
-    dpteqr, dptrfs, dptsv,  dptsvx, dpttrs, dptts2, drscl,
-    dsbev,  dsbevd, dsbevx, dsbgst, dsbgv,  dsbgvd, dsbgvx,
-    dsbtrd,  dspcon, dspev,  dspevd, dspevx, dspgst,
-    dspgv,  dspgvd, dspgvx, dsprfs, dspsv,  dspsvx, dsptrd,
-    dsptrf, dsptri, dsptrs, dstegr, dstein, dstev,  dstevd, dstevr,
-    dstevx,
-    dsycon, dsyev,  dsyevd, dsyevr,
-    dsyevx, dsygs2, dsygst, dsygv,  dsygvd, dsygvx, dsyrfs,
-    dsysv,  dsysvx,
-    dsytd2, dsytf2, dsytrd, dsytrf, dsytri, dsytri2, dsytri2x,
-    dsyswapr, dsytrs, dsytrs2, dsyconv,
-    dtbcon, dtbrfs, dtbtrs, dtgevc, dtgex2, dtgexc, dtgsen,
-    dtgsja, dtgsna, dtgsy2, dtgsyl, dtpcon, dtprfs, dtptri,
-    dtptrs,
-    dtrcon, dtrevc, dtrexc, dtrrfs, dtrsen, dtrsna, dtrsyl,
-    dtrtrs, dtzrzf, dstemr,
-    dsgesv, dsposv, dlag2s, slag2d, dlat2s,
-    dlansf, dpftrf, dpftri, dpftrs, dsfrk, dtfsm, dtftri, dtfttp,
-    dtfttr, dtpttf, dtpttr, dtrttf, dtrttp,
-    dgejsv,  dgesvj,  dgsvj0,  dgsvj1,
-    dgeequb, dsyequb, dpoequb, dgbequb,
-    dbbcsd, dlapmr, dorbdb, dorbdb1, dorbdb2, dorbdb3, dorbdb4,
-    dorbdb5, dorbdb6, dorcsd, dorcsd2by1,
-    dgeqrt, dgeqrt2, dgeqrt3, dgemqrt,
-    dtpqrt, dtpqrt2, dtpmqrt, dtprfb,
-);
-@lapackobjs2z = (
-    # ZLASRC  -- Double precision complex LAPACK routines
-    # already provided by @blasobjs:
-    # already provided by @lapackobjs:
-    #     zgesv, zgetrs, zgetf2, zlaswp, zlauu2, zlauum, zpotf2, zpotrf, zpotri,
-    #     ztrti2, ztrtri
-    zbdsqr, zgbbrd, zgbcon, zgbequ, zgbrfs, zgbsv,  zgbsvx,
-    zgbtf2, zgbtrf, zgbtrs, zgebak, zgebal, zgebd2, zgebrd,
-    zgecon, zgeequ, zgees,  zgeesx, zgeev,  zgeevx,
-    zgehd2, zgehrd, zgelq2, zgelqf,
-    zgels,  zgelsd, zgelss, zgelsy, zgeql2, zgeqlf, zgeqp3,
-    zgeqr2, zgeqr2p, zgeqrf, zgeqrfp, zgerfs, zgerq2, zgerqf,
-    zgesc2, zgesdd, zgesvd, zgesvx, zgetc2,
-    zgetri,
-    zggbak, zggbal, zgges,  zggesx, zggev,  zggevx, zggglm,
-    zgghrd, zgglse, zggqrf, zggrqf,
-    zgtcon, zgtrfs, zgtsv,  zgtsvx, zgttrf, zgttrs, zgtts2, zhbev,
-    zhbevd, zhbevx, zhbgst, zhbgv,  zhbgvd, zhbgvx, zhbtrd,
-    zhecon, zheev,  zheevd, zheevr, zheevx, zhegs2, zhegst,
-    zhegv,  zhegvd, zhegvx, zherfs, zhesv,  zhesvx, zhetd2,
-    zhetf2, zhetrd,
-    zhetrf, zhetri, zhetri2, zhetri2x, zheswapr,
-    zhetrs, zhetrs2, zhgeqz, zhpcon, zhpev,  zhpevd,
-    zhpevx, zhpgst, zhpgv,  zhpgvd, zhpgvx, zhprfs, zhpsv,
-    zhpsvx,
-    zhptrd, zhptrf, zhptri, zhptrs, zhsein, zhseqr, zlabrd,
-    zlacgv, zlacon, zlacn2, zlacp2, zlacpy, zlacrm, zlacrt, zladiv,
-    zlaed0, zlaed7, zlaed8,
-    zlaein, zlaesy, zlaev2, zlags2, zlagtm,
-    zlahef, zlahqr,
-    zlahr2, zlaic1, zlals0, zlalsa, zlalsd, zlangb, zlange,
-    zlangt, zlanhb,
-    zlanhe,
-    zlanhp, zlanhs, zlanht, zlansb, zlansp, zlansy, zlantb,
-    zlantp, zlantr, zlapll, zlapmt, zlaqgb, zlaqge,
-    zlaqhb, zlaqhe, zlaqhp, zlaqp2, zlaqps, zlaqsb,
-    zlaqr0, zlaqr1, zlaqr2, zlaqr3, zlaqr4, zlaqr5,
-    zlaqsp, zlaqsy, zlar1v, zlar2v, ilazlr, ilazlc,
-    zlarcm, zlarf,  zlarfb,
-    zlarfg, zlarft, zlarfgp,
-    zlarfx, zlargv, zlarnv, zlarrv, zlartg, zlartv,
-    zlarz,  zlarzb, zlarzt, zlascl, zlaset, zlasr,
-    zlassq, zlasyf,
-    zlatbs, zlatdf, zlatps, zlatrd, zlatrs, zlatrz,
-    zpbcon, zpbequ, zpbrfs, zpbstf, zpbsv,
-    zpbsvx, zpbtf2, zpbtrf, zpbtrs, zpocon, zpoequ, zporfs,
-    zposv,  zposvx, zpotrs, zpstrf, zpstf2,
-    zppcon, zppequ, zpprfs, zppsv,  zppsvx, zpptrf, zpptri, zpptrs,
-    zptcon, zpteqr, zptrfs, zptsv,  zptsvx, zpttrf, zpttrs, zptts2,
-    zrot,   zspcon, zspmv,  zspr,   zsprfs, zspsv,
-    zspsvx, zsptrf, zsptri, zsptrs, zdrscl, zstedc,
-    zstegr, zstein, zsteqr,
-    zsycon,
-    zsymv,
-    zsyr, zsyrfs, zsysv,  zsysvx, zsytf2, zsytrf, zsytri, zsytri2, zsytri2x,
-    zsyswapr, zsytrs, zsytrs2, zsyconv,
-    ztbcon, ztbrfs, ztbtrs, ztgevc, ztgex2,
-    ztgexc, ztgsen, ztgsja, ztgsna, ztgsy2, ztgsyl, ztpcon,
-    ztprfs, ztptri,
-    ztptrs, ztrcon, ztrevc, ztrexc, ztrrfs, ztrsen, ztrsna,
-    ztrsyl, ztrtrs, ztzrzf, zung2l,
-    zung2r, zungbr, zunghr, zungl2, zunglq, zungql, zungqr, zungr2,
-    zungrq, zungtr, zunm2l, zunm2r, zunmbr, zunmhr, zunml2,
-    zunmlq, zunmql, zunmqr, zunmr2, zunmr3, zunmrq, zunmrz,
-    zunmtr, zupgtr,
-    zupmtr, izmax1, dzsum1, zstemr,
-    zcgesv, zcposv, zlag2c, clag2z, zlat2c,
-    zhfrk, ztfttp, zlanhf, zpftrf, zpftri, zpftrs, ztfsm, ztftri,
-    ztfttr, ztpttf, ztpttr, ztrttf, ztrttp,
-    zgeequb, zgbequb, zsyequb, zpoequb, zheequb,
-    zbbcsd, zlapmr, zunbdb, zunbdb1, zunbdb2, zunbdb3, zunbdb4,
-    zunbdb5, zunbdb6, zuncsd, zuncsd2by1,
-    zgeqrt, zgeqrt2, zgeqrt3, zgemqrt,
-    ztpqrt, ztpqrt2, ztpmqrt, ztprfb,
-);
-    # functions added for lapack-3.6.0
+# ZCLASRC -- Double-single mixed precision complex routines called from
+# single, single-extra and double precision complex LAPACK
+# routines (i.e. from CLASRC, CXLASRC, ZLASRC).
+#
+# already provided by @lapackobjs:
+#     cgetrs, cpotrf, cgetrf
+lapackobjs2zc="
+    cpotrs
+"
 
-@lapackobjs2c = ( @lapackobjs2c,
-    cgejsv,
-    cgesvdx,
-    cgesvj,
-    cgetrf2,
-    cgges3,
-    cggev3,
-    cgghd3,
-    cggsvd3,
-    cggsvp3,
-    cgsvj0,
-    cgsvj1,
-    clagge,
-    claghe,
-    clagsy,
-    clahilb,
-    clakf2,
-    clarge,
-    clarnd,
-    claror,
-    clarot,
-    clatm1,
-    clatm2,
-    clatm3,
-    clatm5,
-    clatm6,
-    clatme,
-    clatmr,
-    clatms,
-    clatmt,
-    cpotrf2,
-    csbmv,
-    cspr2,
-    csyr2,
-    cunm22,
-);
-@lapackobjs2d = (@lapackobjs2d,
-    dbdsvdx,
-    dgesvdx,
-    dgetrf2,
-    dgges3,
-    dggev3,
-    dgghd3,
-    dggsvd3,
-    dggsvp3,
-    dladiv2,
-    dlagge,
-    dlagsy,
-    dlahilb,
-    dlakf2,
-    dlaran,
-    dlarge,
-    dlarnd,
-    dlaror,
-    dlarot,
-    dlatm1,
-    dlatm2,
-    dlatm3,
-    dlatm5,
-    dlatm6,
-    dlatm7,
-    dlatme,
-    dlatmr,
-    dlatms,
-    dlatmt,
-    dorm22,
-    dpotrf2,
-    dsecnd,
-    );
-    @lapackobjs2s = (@lapackobjs2s,
-    sbdsvdx,
-    second,
-    sgesvdx,
-    sgetrf2,
-    sgges3,
-    sggev3,
-    sgghd3,
-    sggsvd3,
-    sggsvp3,
-    sladiv2,
-    slagge,
-    slagsy,
-    slahilb,
-    slakf2,
-    slaran,
-    slarge,
-    slarnd,
-    slaror,
-    slarot,
-    slatm1,
-    slatm2,
-    slatm3,
-    slatm5,
-    slatm6,
-    slatm7,
-    slatme,
-    slatmr,
-    slatms,
-    slatmt,
-    sorm22,
-    spotrf2,
-    );
-    @lapackobjs2z = (@lapackobjs2z,
-    zgejsv,
-    zgesvdx,
-    zgesvj,
-    zgetrf2,
-    zgges3,
-    zggev3,
-    zgghd3,
-    zggsvd3,
-    zggsvp3,
-    zgsvj0,
-    zgsvj1,
-    zlagge,
-    zlaghe,
-    zlagsy,
-    zlahilb,
-    zlakf2,
-    zlarge,
-    zlarnd,
-    zlaror,
-    zlarot,
-    zlatm1,
-    zlatm2,
-    zlatm3,
-    zlatm5,
-    zlatm6,
-    zlatme,
-    zlatmr,
-    zlatms,
-    zlatmt,
-    zpotrf2,
-    zsbmv,
-    zspr2,
-    zsyr2,
-    zunm22,
-);
-    # functions added for lapack-3.7.0
-@lapackobjs2s = (@lapackobjs2s,
-    slarfy,
-    strevc3,
-    sgelqt,
-    sgelqt3,
-    sgemlqt,
-    sgetsls,
-    sgeqr,
-    slatsqr,
-    slamtsqr,
-    sgemqr,
-    sgelq,
-    slaswlq,
-    slamswlq,
-    sgemlq,
-    stplqt,
-    stplqt2,
-    stpmlqt,
-    );
-    @lapackobjs2d = (@lapackobjs2d,
-    dlarfy,
-    dsyconvf,
-    dtrevc3,
-    dgelqt,
-    dgelqt3,
-    dgemlqt,
-    dgetsls,
-    dgeqr,
-    dlatsqr,
-    dlamtsqr,
-    dgemqr,
-    dgelq,
-    dlaswlq,
-    dlamswlq,
-    dgemlq,
-    dtplqt,
-    dtplqt2,
-    dtpmlqt,
-    );
-    @lapackobjs2c = (@lapackobjs2c,
-    clarfy,
-    csyconvf,
-    ctrevc3,
-    cgelqt,
-    cgelqt3,
-    cgemlqt,
-    cgetsls,
-    cgeqr,
-    clatsqr,
-    clamtsqr,
-    cgemqr,
-    cgelq,
-    claswlq,
-    clamswlq,
-    cgemlq,
-    ctplqt,
-    ctplqt2,
-    ctpmlqt,
-    );
-    @lapackobjs2z = (@lapackobjs2z,
-    zlarfy,
-    zsyconvf,
-    ztrevc3,
-    ztplqt,
-    ztplqt2,
-    ztpmlqt,
-    zgelqt,
-    zgelqt3,
-    zgemlqt,
-    zgetsls,
-    zgeqr,
-    zlatsqr,
-    zlamtsqr,
-    zgemqr,
-    zgelq,
-    zlaswlq,
-    zlamswlq,
-    zgemlq,
-    );
-    @lapackobjs2s = (@lapackobjs2s,
-    sladiv1);
-    @lapackobjs2d = (@lapackobjs2d,
-    dladiv1);
-    @lapackobjs = (@lapackobjs,
-    iparam2stage,
-    # functions added for lapack-3.8.0
-    ilaenv2stage,
-    );
-    # functions added for lapack-3.9.0
-@lapackobjs2c = (@lapackobjs2c,
-    cgesvdq,
+# DLASRC  -- Double precision real LAPACK routines
+# already provided by @lapackobjs:
+#     dgesv, dgetf2, dgetrs, dlaswp, dlauu2, dlauum, dpotf2, dpotrf, dpotri,
+#     dtrti2, dtrtri
+lapackobjs2d="
+    dgbbrd dgbcon dgbequ dgbrfs dgbsv
+    dgbsvx dgbtf2 dgbtrf dgbtrs dgebak dgebal dgebd2
+    dgebrd dgecon dgeequ dgees  dgeesx dgeev  dgeevx
+    dgehd2 dgehrd dgelq2 dgelqf
+    dgels  dgelsd dgelss dgelsy dgeql2 dgeqlf
+    dgeqp3 dgeqr2 dgeqr2p dgeqrf dgeqrfp dgerfs
+    dgerq2 dgerqf dgesc2 dgesdd dgesvd dgesvx
+    dgetc2 dgetri
+    dggbak dggbal dgges  dggesx dggev  dggevx
+    dggglm dgghrd dgglse dggqrf
+    dggrqf dgtcon dgtrfs dgtsv
+    dgtsvx dgttrf dgttrs dgtts2 dhgeqz
+    dhsein dhseqr dlabrd dlacon dlacn2
+    dlaein dlaexc dlag2  dlags2 dlagtm dlagv2 dlahqr
+    dlahr2 dlaic1 dlaln2 dlals0 dlalsa dlalsd
+    dlangb dlange dlangt dlanhs dlansb dlansp
+    dlansy dlantb dlantp dlantr dlanv2
+    dlapll dlapmt
+    dlaqgb dlaqge dlaqp2 dlaqps dlaqsb dlaqsp dlaqsy
+    dlaqr0 dlaqr1 dlaqr2 dlaqr3 dlaqr4 dlaqr5
+    dlaqtr dlar1v dlar2v iladlr iladlc
+    dlarf  dlarfb dlarfg dlarfgp dlarft dlarfx
+    dlargv dlarrv dlartv
+    dlarz  dlarzb dlarzt dlasy2 dlasyf
+    dlatbs dlatdf dlatps dlatrd dlatrs dlatrz
+    dopgtr dopmtr dorg2l dorg2r
+    dorgbr dorghr dorgl2 dorglq dorgql dorgqr dorgr2
+    dorgrq dorgtr dorm2l dorm2r
+    dormbr dormhr dorml2 dormlq dormql dormqr dormr2
+    dormr3 dormrq dormrz dormtr dpbcon dpbequ dpbrfs
+    dpbstf dpbsv  dpbsvx
+    dpbtf2 dpbtrf dpbtrs dpocon dpoequ dporfs dposv
+    dposvx dpotrs dpstrf dpstf2
+    dppcon dppequ
+    dpprfs dppsv  dppsvx dpptrf dpptri dpptrs dptcon
+    dpteqr dptrfs dptsv  dptsvx dpttrs dptts2 drscl
+    dsbev  dsbevd dsbevx dsbgst dsbgv  dsbgvd dsbgvx
+    dsbtrd  dspcon dspev  dspevd dspevx dspgst
+    dspgv  dspgvd dspgvx dsprfs dspsv  dspsvx dsptrd
+    dsptrf dsptri dsptrs dstegr dstein dstev  dstevd dstevr
+    dstevx
+    dsycon dsyev  dsyevd dsyevr
+    dsyevx dsygs2 dsygst dsygv  dsygvd dsygvx dsyrfs
+    dsysv  dsysvx
+    dsytd2 dsytf2 dsytrd dsytrf dsytri dsytri2 dsytri2x
+    dsyswapr dsytrs dsytrs2 dsyconv
+    dtbcon dtbrfs dtbtrs dtgevc dtgex2 dtgexc dtgsen
+    dtgsja dtgsna dtgsy2 dtgsyl dtpcon dtprfs dtptri
+    dtptrs
+    dtrcon dtrevc dtrexc dtrrfs dtrsen dtrsna dtrsyl
+    dtrtrs dtzrzf dstemr
+    dsgesv dsposv dlag2s slag2d dlat2s
+    dlansf dpftrf dpftri dpftrs dsfrk dtfsm dtftri dtfttp
+    dtfttr dtpttf dtpttr dtrttf dtrttp
+    dgejsv  dgesvj  dgsvj0  dgsvj1
+    dgeequb dsyequb dpoequb dgbequb
+    dbbcsd dlapmr dorbdb dorbdb1 dorbdb2 dorbdb3 dorbdb4
+    dorbdb5 dorbdb6 dorcsd dorcsd2by1
+    dgeqrt dgeqrt2 dgeqrt3 dgemqrt
+    dtpqrt dtpqrt2 dtpmqrt dtprfb
+"
+
+# ZLASRC  -- Double precision complex LAPACK routines
+# already provided by b"asobjs:
+# already provided by @lapackobjs:
+#     zgesv zgetrs zgetf2 zlaswp zlauu2 zlauum zpotf2 zpotrf zpotri
+#     ztrti2 ztrtri
+lapackobjs2z="
+    zbdsqr zgbbrd zgbcon zgbequ zgbrfs zgbsv  zgbsvx
+    zgbtf2 zgbtrf zgbtrs zgebak zgebal zgebd2 zgebrd
+    zgecon zgeequ zgees  zgeesx zgeev  zgeevx
+    zgehd2 zgehrd zgelq2 zgelqf
+    zgels  zgelsd zgelss zgelsy zgeql2 zgeqlf zgeqp3
+    zgeqr2 zgeqr2p zgeqrf zgeqrfp zgerfs zgerq2 zgerqf
+    zgesc2 zgesdd zgesvd zgesvx zgetc2
+    zgetri
+    zggbak zggbal zgges  zggesx zggev  zggevx zggglm
+    zgghrd zgglse zggqrf zggrqf
+    zgtcon zgtrfs zgtsv  zgtsvx zgttrf zgttrs zgtts2 zhbev
+    zhbevd zhbevx zhbgst zhbgv  zhbgvd zhbgvx zhbtrd
+    zhecon zheev  zheevd zheevr zheevx zhegs2 zhegst
+    zhegv  zhegvd zhegvx zherfs zhesv  zhesvx zhetd2
+    zhetf2 zhetrd
+    zhetrf zhetri zhetri2 zhetri2x zheswapr
+    zhetrs zhetrs2 zhgeqz zhpcon zhpev  zhpevd
+    zhpevx zhpgst zhpgv  zhpgvd zhpgvx zhprfs zhpsv
+    zhpsvx
+    zhptrd zhptrf zhptri zhptrs zhsein zhseqr zlabrd
+    zlacgv zlacon zlacn2 zlacp2 zlacpy zlacrm zlacrt zladiv
+    zlaed0 zlaed7 zlaed8
+    zlaein zlaesy zlaev2 zlags2 zlagtm
+    zlahef zlahqr
+    zlahr2 zlaic1 zlals0 zlalsa zlalsd zlangb zlange
+    zlangt zlanhb
+    zlanhe
+    zlanhp zlanhs zlanht zlansb zlansp zlansy zlantb
+    zlantp zlantr zlapll zlapmt zlaqgb zlaqge
+    zlaqhb zlaqhe zlaqhp zlaqp2 zlaqps zlaqsb
+    zlaqr0 zlaqr1 zlaqr2 zlaqr3 zlaqr4 zlaqr5
+    zlaqsp zlaqsy zlar1v zlar2v ilazlr ilazlc
+    zlarcm zlarf  zlarfb
+    zlarfg zlarft zlarfgp
+    zlarfx zlargv zlarnv zlarrv zlartg zlartv
+    zlarz  zlarzb zlarzt zlascl zlaset zlasr
+    zlassq zlasyf
+    zlatbs zlatdf zlatps zlatrd zlatrs zlatrz
+    zpbcon zpbequ zpbrfs zpbstf zpbsv
+    zpbsvx zpbtf2 zpbtrf zpbtrs zpocon zpoequ zporfs
+    zposv  zposvx zpotrs zpstrf zpstf2
+    zppcon zppequ zpprfs zppsv  zppsvx zpptrf zpptri zpptrs
+    zptcon zpteqr zptrfs zptsv  zptsvx zpttrf zpttrs zptts2
+    zrot   zspcon zspmv  zspr   zsprfs zspsv
+    zspsvx zsptrf zsptri zsptrs zdrscl zstedc
+    zstegr zstein zsteqr
+    zsycon
+    zsymv
+    zsyr zsyrfs zsysv  zsysvx zsytf2 zsytrf zsytri zsytri2 zsytri2x
+    zsyswapr zsytrs zsytrs2 zsyconv
+    ztbcon ztbrfs ztbtrs ztgevc ztgex2
+    ztgexc ztgsen ztgsja ztgsna ztgsy2 ztgsyl ztpcon
+    ztprfs ztptri
+    ztptrs ztrcon ztrevc ztrexc ztrrfs ztrsen ztrsna
+    ztrsyl ztrtrs ztzrzf zung2l
+    zung2r zungbr zunghr zungl2 zunglq zungql zungqr zungr2
+    zungrq zungtr zunm2l zunm2r zunmbr zunmhr zunml2
+    zunmlq zunmql zunmqr zunmr2 zunmr3 zunmrq zunmrz
+    zunmtr zupgtr
+    zupmtr izmax1 dzsum1 zstemr
+    zcgesv zcposv zlag2c clag2z zlat2c
+    zhfrk ztfttp zlanhf zpftrf zpftri zpftrs ztfsm ztftri
+    ztfttr ztpttf ztpttr ztrttf ztrttp
+    zgeequb zgbequb zsyequb zpoequb zheequb
+    zbbcsd zlapmr zunbdb zunbdb1 zunbdb2 zunbdb3 zunbdb4
+    zunbdb5 zunbdb6 zuncsd zuncsd2by1
+    zgeqrt zgeqrt2 zgeqrt3 zgemqrt
+    ztpqrt ztpqrt2 ztpmqrt ztprfb
+"
+
+# functions added for lapack-3.6.0
+
+lapackobjs2c="$lapackobjs2c
+    cgejsv
+    cgesvdx
+    cgesvj
+    cgetrf2
+    cgges3
+    cggev3
+    cgghd3
+    cggsvd3
+    cggsvp3
+    cgsvj0
+    cgsvj1
+    clagge
+    claghe
+    clagsy
+    clahilb
+    clakf2
+    clarge
+    clarnd
+    claror
+    clarot
+    clatm1
+    clatm2
+    clatm3
+    clatm5
+    clatm6
+    clatme
+    clatmr
+    clatms
+    clatmt
+    cpotrf2
+    csbmv
+    cspr2
+    csyr2
+    cunm22
+"
+
+lapackobjs2d="$lapackobjs2d
+    dbdsvdx
+    dgesvdx
+    dgetrf2
+    dgges3
+    dggev3
+    dgghd3
+    dggsvd3
+    dggsvp3
+    dladiv2
+    dlagge
+    dlagsy
+    dlahilb
+    dlakf2
+    dlaran
+    dlarge
+    dlarnd
+    dlaror
+    dlarot
+    dlatm1
+    dlatm2
+    dlatm3
+    dlatm5
+    dlatm6
+    dlatm7
+    dlatme
+    dlatmr
+    dlatms
+    dlatmt
+    dorm22
+    dpotrf2
+    dsecnd
+"
+
+lapackobjs2s="$lapackobjs2s
+    sbdsvdx
+    second
+    sgesvdx
+    sgetrf2
+    sgges3
+    sggev3
+    sgghd3
+    sggsvd3
+    sggsvp3
+    sladiv2
+    slagge
+    slagsy
+    slahilb
+    slakf2
+    slaran
+    slarge
+    slarnd
+    slaror
+    slarot
+    slatm1
+    slatm2
+    slatm3
+    slatm5
+    slatm6
+    slatm7
+    slatme
+    slatmr
+    slatms
+    slatmt
+    sorm22
+    spotrf2
+"
+
+lapackobjs2z="$lapackobjs2z
+    zgejsv
+    zgesvdx
+    zgesvj
+    zgetrf2
+    zgges3
+    zggev3
+    zgghd3
+    zggsvd3
+    zggsvp3
+    zgsvj0
+    zgsvj1
+    zlagge
+    zlaghe
+    zlagsy
+    zlahilb
+    zlakf2
+    zlarge
+    zlarnd
+    zlaror
+    zlarot
+    zlatm1
+    zlatm2
+    zlatm3
+    zlatm5
+    zlatm6
+    zlatme
+    zlatmr
+    zlatms
+    zlatmt
+    zpotrf2
+    zsbmv
+    zspr2
+    zsyr2
+    zunm22
+"
+
+# functions added for lapack-3.7.0
+lapackobjs2s="$lapackobjs2s
+    slarfy
+    ssyconvf
+    strevc3
+    sgelqt
+    sgelqt3
+    sgemlqt
+    sgetsls
+    sgeqr
+    slatsqr
+    slamtsqr
+    sgemqr
+    sgelq
+    slaswlq
+    slamswlq
+    sgemlq
+    stplqt
+    stplqt2
+    stpmlqt
+"
+
+lapackobjs2d="$lapackobjs2d
+    dlarfy
+    dsyconvf
+    dtrevc3
+    dgelqt
+    dgelqt3
+    dgemlqt
+    dgetsls
+    dgeqr
+    dlatsqr
+    dlamtsqr
+    dgemqr
+    dgelq
+    dlaswlq
+    dlamswlq
+    dgemlq
+    dtplqt
+    dtplqt2
+    dtpmlqt
+    "
+lapackobjs2c="$lapackobjs2c
+    clarfy
+    csyconvf
+    ctrevc3
+    cgelqt
+    cgelqt3
+    cgemlqt
+    cgetsls
+    cgeqr
+    clatsqr
+    clamtsqr
+    cgemqr
+    cgelq
+    claswlq
+    clamswlq
+    cgemlq
+    ctplqt
+    ctplqt2
+    ctpmlqt
+"
+lapackobjs2z="$lapackobjs2z
+    zlarfy
+    zsyconvf
+    ztrevc3
+    ztplqt
+    ztplqt2
+    ztpmlqt
+    zgelqt
+    zgelqt3
+    zgemlqt
+    zgetsls
+    zgeqr
+    zlatsqr
+    zlamtsqr
+    zgemqr
+    zgelq
+    zlaswlq
+    zlamswlq
+    zgemlq
+"
+
+lapackobjs2s="$lapackobjs2s
+sladiv1"
+
+lapackobjs2d="$lapackobjs2d
+dladiv1"
+
+lapackobjs="$lapackobjs
+iparam2stage
+ilaenv2stage
+"
+
+# functions added for lapack-3.9.0
+lapackobjs2c="$lapackobjs2c
+    cgesvdq
     cungtsqr
-    );
-@lapackobjs2d = (@lapackobjs2d,
-    dcombssq,
-    dgesvdq,
-    dorgtsqr,
-    );
-@lapackobjs2s = (@lapackobjs2s,
-    scombssq,
-    sgesvdq,
-    sorgtsqr,
-    );
-@lapackobjs2z = (@lapackobjs2z,
-    zgesvdq,
+    "
+lapackobjs2d="$lapackobjs2d
+    dcombssq
+    dgesvdq
+    dorgtsqr
+    "
+lapackobjs2s="$lapackobjs2s
+    scombssq
+    sgesvdq
+    sorgtsqr
+    "
+lapackobjs2z="$lapackobjs2z
+    zgesvdq
     zungtsqr
-);
+    "
+#functions added for lapack-3.10
+lapackobjs2c="$lapackobjs2c
+    cgetsqrhrt
+    cungtsqr_row
+    "
+lapackobjs2d="$lapackobjs2d
+    dgetsqrhrt
+    dorgtsqr_row
+    "
+lapackobjs2s="$lapackobjs2s
+    sgetsqrhrt
+    sorgtsqr_row
+    "
+lapackobjs2z="$lapackobjs2z
+    zgetsqrhrt
+    zungtsqr_row
+    "
 
-@lapack_extendedprecision_objs = (
-    zposvxx, clagge, clatms, chesvxx, cposvxx, cgesvxx, ssyrfssx, csyrfsx,
-    dlagsy, dsysvxx, sporfsx, slatms, zlatms, zherfsx, csysvxx,
-);
+#functions added for lapack-3.11
+lapackobjs2c="$lapackobjs2c
+    cgedmd
+    cgedmdq
+    "
+lapackobjs2d="$lapackobjs2d
+    dgedmd
+    dgedmdq
+    "
+lapackobjs2s="$lapackobjs2s
+    sgedmd
+    sgedmdq
+    "
+lapackobjs2z="$lapackobjs2z
+    zgedmd
+    zgedmdq
+    "
 
-@lapack_deprecated_objsc = (
-    cgegs,   cggsvd,  
-    cgegv,   cggsvp,  
-    cgelsx,  clahrd,  
-    cgeqpf,  clatzm,  
-    ctzrqf,
-    );
-@lapack_deprecated_objsd = (
-    dgegs,   dgeqpf,
-    dgegv,   dggsvd,
-    dgelsx,  dggsvp,
-             dlahrd,
-  dlatzm,  dtzrqf);
-  
-@lapack_deprecated_objss = ( 
-  sgelsx,
-  sgegs,
-  sgegv,
-  sgeqpf,
-  sggsvd,
-  sggsvp,
-  slahrd,
-  slatzm,
+#functions added post 3.11
+
+lapackobjs2c="$lapackobjs2c
+    claqp2rk
+    claqp3rk
+    ctrsyl3
+    "
+#    claqz0
+#    claqz1
+#    claqz2
+#    claqz3
+#    clatrs3
+
+lapackobjs2d="$lapackobjs2d
+    dgelqs
+    dgelst
+    dgeqp3rk
+    dgeqrs
+    dlaqp2rk
+    dlaqp3rk
+    dlarmm
+    dlatrs3
+    dtrsyl3
+    "
+#    dlaqz0
+#    dlaqz1
+#    dlaqz2
+#    dlaqz3
+#    dlaqz4
+
+lapackobjs2z="$lapackobjs2z
+    zgelqs
+    zgelst
+    zgeqp3rk
+    zgeqrs
+    zlaqp2rk
+    zlaqp3rk
+    zlatrs3
+    zrscl
+    ztrsyl3
+    "
+#    zlaqz0
+#    zlaqz1
+#    zlaqz2
+#    zlaqz3
+
+lapack_extendedprecision_objs="
+    zposvxx clagge clatms chesvxx cposvxx cgesvxx ssyrfssx csyrfsx
+    dlagsy dsysvxx sporfsx slatms zlatms zherfsx csysvxx
+"
+
+lapack_deprecated_objsc="
+    cgegs   cggsvd
+    cgegv   cggsvp
+    cgelsx  clahrd
+    cgeqpf  clatzm
+    ctzrqf
+    "
+
+lapack_deprecated_objsd="
+    dgegs   dgeqpf
+    dgegv   dggsvd
+    dgelsx  dggsvp
+             dlahrd
+  dlatzm  dtzrqf"
+
+lapack_deprecated_objss="
+  sgelsx
+  sgegs
+  sgegv
+  sgeqpf
+  sggsvd
+  sggsvp
+  slahrd
+  slatzm
   stzrqf
-  );
+  "
 
-@lapack_deprecated_objsz = ( 
-  zgegs,
-  zgegv,
-  zgelsx,
-  zgeqpf,
-  zggsvd,
-  zggsvp,
-  zlahrd,
-  zlatzm,
+lapack_deprecated_objsz="
+  zgegs
+  zgegv
+  zgelsx
+  zgeqpf
+  zggsvd
+  zggsvp
+  zlahrd
+  zlatzm
   ztzrqf
-  );
+  "
 
-@lapacke_deprecated_objsc = (
-    LAPACKE_cggsvp,
-    LAPACKE_cggsvp_work,
-    LAPACKE_cggsvd,
-    LAPACKE_cggsvd_work,
-    LAPACKE_cgeqpf,
-    LAPACKE_cgeqpf_work,
-);  
-@lapacke_deprecated_objsd = (    
-    LAPACKE_dggsvp,
-    LAPACKE_dggsvp_work,
-    LAPACKE_dggsvd,
-    LAPACKE_dggsvd_work,
-    LAPACKE_dgeqpf,
-    LAPACKE_dgeqpf_work,
-);    
-@lapacke_deprecated_objss = (    
-    LAPACKE_sggsvp,
-    LAPACKE_sggsvp_work,
-    LAPACKE_sggsvd,
-    LAPACKE_sggsvd_work,
-    LAPACKE_sgeqpf,
-    LAPACKE_sgeqpf_work,
-);    
-@lapacke_deprecated_objsz = (    
-    LAPACKE_zggsvp,
-    LAPACKE_zggsvp_work,
-    LAPACKE_zggsvd,
-    LAPACKE_zggsvd_work,
-    LAPACKE_zgeqpf,
-    LAPACKE_zgeqpf_work,
-);
+lapacke_deprecated_objsc="
+    LAPACKE_cggsvp
+    LAPACKE_cggsvp_work
+    LAPACKE_cggsvd
+    LAPACKE_cggsvd_work
+    LAPACKE_cgeqpf
+    LAPACKE_cgeqpf_work
+"
 
+lapacke_deprecated_objsd="
+    LAPACKE_dggsvp
+    LAPACKE_dggsvp_work
+    LAPACKE_dggsvd
+    LAPACKE_dggsvd_work
+    LAPACKE_dgeqpf
+    LAPACKE_dgeqpf_work
+"
 
-@lapackeobjs = (
-    # LAPACK C interface routines.
-    #
-    # This list is prepared in a similar manner to @lapackobjs2, however the
-    # functions all begin with an uppercase prefix (with the exception of the
-    # make_complex_* routines).
-    #
-    # The functions corresponding to @(MATGEN_OBJ) and @(SRCX_OBJ) are not
-    # exported since the respective LAPACK routines are not built by default.
+lapacke_deprecated_objss="
+    LAPACKE_sggsvp
+    LAPACKE_sggsvp_work
+    LAPACKE_sggsvd
+    LAPACKE_sggsvd_work
+    LAPACKE_sgeqpf
+    LAPACKE_sgeqpf_work
+"
 
-    # @(OBJ) from `lapack-3.4.1/lapacke/utils/Makefile`
-    LAPACKE_lsame,
-    LAPACKE_ilaver,
-    LAPACKE_xerbla,
-    lapack_make_complex_float,
-    lapack_make_complex_double,
-    LAPACKE_get_nancheck,
-    LAPACKE_set_nancheck,
-);
-@lapackeobjsc = (
-    LAPACKE_cgb_nancheck,
-    LAPACKE_cgb_trans,
-    LAPACKE_cge_nancheck,
-    LAPACKE_cge_trans,
-    LAPACKE_cgg_nancheck,
-    LAPACKE_cgg_trans,
-    LAPACKE_cgt_nancheck,
-    LAPACKE_chb_nancheck,
-    LAPACKE_chb_trans,
-    LAPACKE_che_nancheck,
-    LAPACKE_che_trans,
-    LAPACKE_chp_nancheck,
-    LAPACKE_chp_trans,
-    LAPACKE_chs_nancheck,
-    LAPACKE_chs_trans,
-    LAPACKE_c_nancheck,
-    LAPACKE_cpb_nancheck,
-    LAPACKE_cpb_trans,
-    LAPACKE_cpf_nancheck,
-    LAPACKE_cpf_trans,
-    LAPACKE_cpo_nancheck,
-    LAPACKE_cpo_trans,
-    LAPACKE_cpp_nancheck,
-    LAPACKE_cpp_trans,
-    LAPACKE_cpt_nancheck,
-    LAPACKE_csp_nancheck,
-    LAPACKE_csp_trans,
-    LAPACKE_cst_nancheck,
-    LAPACKE_csy_nancheck,
-    LAPACKE_csy_trans,
-    LAPACKE_ctb_nancheck,
-    LAPACKE_ctb_trans,
-    LAPACKE_ctf_nancheck,
-    LAPACKE_ctf_trans,
-    LAPACKE_ctp_nancheck,
-    LAPACKE_ctp_trans,
-    LAPACKE_ctr_nancheck,
-    LAPACKE_ctr_trans,
-    LAPACKE_cbbcsd,
-    LAPACKE_cbbcsd_work,
-    LAPACKE_cbdsqr,
-    LAPACKE_cbdsqr_work,
-    LAPACKE_cgbbrd,
-    LAPACKE_cgbbrd_work,
-    LAPACKE_cgbcon,
-    LAPACKE_cgbcon_work,
-    LAPACKE_cgbequ,
-    LAPACKE_cgbequ_work,
-    LAPACKE_cgbequb,
-    LAPACKE_cgbequb_work,
-    LAPACKE_cgbrfs,
-    LAPACKE_cgbrfs_work,
-    LAPACKE_cgbsv,
-    LAPACKE_cgbsv_work,
-    LAPACKE_cgbsvx,
-    LAPACKE_cgbsvx_work,
-    LAPACKE_cgbtrf,
-    LAPACKE_cgbtrf_work,
-    LAPACKE_cgbtrs,
-    LAPACKE_cgbtrs_work,
-    LAPACKE_cgebak,
-    LAPACKE_cgebak_work,
-    LAPACKE_cgebal,
-    LAPACKE_cgebal_work,
-    LAPACKE_cgebrd,
-    LAPACKE_cgebrd_work,
-    LAPACKE_cgecon,
-    LAPACKE_cgecon_work,
-    LAPACKE_cgeequ,
-    LAPACKE_cgeequ_work,
-    LAPACKE_cgeequb,
-    LAPACKE_cgeequb_work,
-    LAPACKE_cgees,
-    LAPACKE_cgees_work,
-    LAPACKE_cgeesx,
-    LAPACKE_cgeesx_work,
-    LAPACKE_cgeev,
-    LAPACKE_cgeev_work,
-    LAPACKE_cgeevx,
-    LAPACKE_cgeevx_work,
-    LAPACKE_cgehrd,
-    LAPACKE_cgehrd_work,
-    LAPACKE_cgelq2,
-    LAPACKE_cgelq2_work,
-    LAPACKE_cgelqf,
-    LAPACKE_cgelqf_work,
-    LAPACKE_cgels,
-    LAPACKE_cgels_work,
-    LAPACKE_cgelsd,
-    LAPACKE_cgelsd_work,
-    LAPACKE_cgelss,
-    LAPACKE_cgelss_work,
-    LAPACKE_cgelsy,
-    LAPACKE_cgelsy_work,
-    LAPACKE_cgemqrt,
-    LAPACKE_cgemqrt_work,
-    LAPACKE_cgeqlf,
-    LAPACKE_cgeqlf_work,
-    LAPACKE_cgeqp3,
-    LAPACKE_cgeqp3_work,
-    LAPACKE_cgeqr2,
-    LAPACKE_cgeqr2_work,
-    LAPACKE_cgeqrf,
-    LAPACKE_cgeqrf_work,
-    LAPACKE_cgeqrfp,
-    LAPACKE_cgeqrfp_work,
-    LAPACKE_cgeqrt,
-    LAPACKE_cgeqrt2,
-    LAPACKE_cgeqrt2_work,
-    LAPACKE_cgeqrt3,
-    LAPACKE_cgeqrt3_work,
-    LAPACKE_cgeqrt_work,
-    LAPACKE_cgerfs,
-    LAPACKE_cgerfs_work,
-    LAPACKE_cgerqf,
-    LAPACKE_cgerqf_work,
-    LAPACKE_cgesdd,
-    LAPACKE_cgesdd_work,
-    LAPACKE_cgesv,
-    LAPACKE_cgesv_work,
-    LAPACKE_cgesvd,
-    LAPACKE_cgesvd_work,
-    LAPACKE_cgesvx,
-    LAPACKE_cgesvx_work,
-    LAPACKE_cgetf2,
-    LAPACKE_cgetf2_work,
-    LAPACKE_cgetrf,
-    LAPACKE_cgetrf_work,
-    LAPACKE_cgetri,
-    LAPACKE_cgetri_work,
-    LAPACKE_cgetrs,
-    LAPACKE_cgetrs_work,
-    LAPACKE_cggbak,
-    LAPACKE_cggbak_work,
-    LAPACKE_cggbal,
-    LAPACKE_cggbal_work,
-    LAPACKE_cgges,
-    LAPACKE_cgges_work,
-    LAPACKE_cggesx,
-    LAPACKE_cggesx_work,
-    LAPACKE_cggev,
-    LAPACKE_cggev_work,
-    LAPACKE_cggevx,
-    LAPACKE_cggevx_work,
-    LAPACKE_cggglm,
-    LAPACKE_cggglm_work,
-    LAPACKE_cgghrd,
-    LAPACKE_cgghrd_work,
-    LAPACKE_cgglse,
-    LAPACKE_cgglse_work,
-    LAPACKE_cggqrf,
-    LAPACKE_cggqrf_work,
-    LAPACKE_cggrqf,
-    LAPACKE_cggrqf_work,
-    LAPACKE_cgtcon,
-    LAPACKE_cgtcon_work,
-    LAPACKE_cgtrfs,
-    LAPACKE_cgtrfs_work,
-    LAPACKE_cgtsv,
-    LAPACKE_cgtsv_work,
-    LAPACKE_cgtsvx,
-    LAPACKE_cgtsvx_work,
-    LAPACKE_cgttrf,
-    LAPACKE_cgttrf_work,
-    LAPACKE_cgttrs,
-    LAPACKE_cgttrs_work,
-    LAPACKE_chbev,
-    LAPACKE_chbev_work,
-    LAPACKE_chbevd,
-    LAPACKE_chbevd_work,
-    LAPACKE_chbevx,
-    LAPACKE_chbevx_work,
-    LAPACKE_chbgst,
-    LAPACKE_chbgst_work,
-    LAPACKE_chbgv,
-    LAPACKE_chbgv_work,
-    LAPACKE_chbgvd,
-    LAPACKE_chbgvd_work,
-    LAPACKE_chbgvx,
-    LAPACKE_chbgvx_work,
-    LAPACKE_chbtrd,
-    LAPACKE_chbtrd_work,
-    LAPACKE_checon,
-    LAPACKE_checon_work,
-    LAPACKE_cheequb,
-    LAPACKE_cheequb_work,
-    LAPACKE_cheev,
-    LAPACKE_cheev_work,
-    LAPACKE_cheevd,
-    LAPACKE_cheevd_work,
-    LAPACKE_cheevr,
-    LAPACKE_cheevr_work,
-    LAPACKE_cheevx,
-    LAPACKE_cheevx_work,
-    LAPACKE_chegst,
-    LAPACKE_chegst_work,
-    LAPACKE_chegv,
-    LAPACKE_chegv_work,
-    LAPACKE_chegvd,
-    LAPACKE_chegvd_work,
-    LAPACKE_chegvx,
-    LAPACKE_chegvx_work,
-    LAPACKE_cherfs,
-    LAPACKE_cherfs_work,
-    LAPACKE_chesv,
-    LAPACKE_chesv_work,
-    LAPACKE_chesvx,
-    LAPACKE_chesvx_work,
-    LAPACKE_cheswapr,
-    LAPACKE_cheswapr_work,
-    LAPACKE_chetrd,
-    LAPACKE_chetrd_work,
-    LAPACKE_chetrf,
-    LAPACKE_chetrf_work,
-    LAPACKE_chetri,
-    LAPACKE_chetri2,
-    LAPACKE_chetri2_work,
-    LAPACKE_chetri2x,
-    LAPACKE_chetri2x_work,
-    LAPACKE_chetri_work,
-    LAPACKE_chetrs,
-    LAPACKE_chetrs2,
-    LAPACKE_chetrs2_work,
-    LAPACKE_chetrs_work,
-    LAPACKE_chfrk,
-    LAPACKE_chfrk_work,
-    LAPACKE_chgeqz,
-    LAPACKE_chgeqz_work,
-    LAPACKE_chpcon,
-    LAPACKE_chpcon_work,
-    LAPACKE_chpev,
-    LAPACKE_chpev_work,
-    LAPACKE_chpevd,
-    LAPACKE_chpevd_work,
-    LAPACKE_chpevx,
-    LAPACKE_chpevx_work,
-    LAPACKE_chpgst,
-    LAPACKE_chpgst_work,
-    LAPACKE_chpgv,
-    LAPACKE_chpgv_work,
-    LAPACKE_chpgvd,
-    LAPACKE_chpgvd_work,
-    LAPACKE_chpgvx,
-    LAPACKE_chpgvx_work,
-    LAPACKE_chprfs,
-    LAPACKE_chprfs_work,
-    LAPACKE_chpsv,
-    LAPACKE_chpsv_work,
-    LAPACKE_chpsvx,
-    LAPACKE_chpsvx_work,
-    LAPACKE_chptrd,
-    LAPACKE_chptrd_work,
-    LAPACKE_chptrf,
-    LAPACKE_chptrf_work,
-    LAPACKE_chptri,
-    LAPACKE_chptri_work,
-    LAPACKE_chptrs,
-    LAPACKE_chptrs_work,
-    LAPACKE_chsein,
-    LAPACKE_chsein_work,
-    LAPACKE_chseqr,
-    LAPACKE_chseqr_work,
-    LAPACKE_clacgv,
-    LAPACKE_clacgv_work,
-    LAPACKE_clacn2,
-    LAPACKE_clacn2_work,
-    LAPACKE_clacp2,
-    LAPACKE_clacp2_work,
-    LAPACKE_clacpy,
-    LAPACKE_clacpy_work,
-    LAPACKE_clag2z,
-    LAPACKE_clag2z_work,
-    LAPACKE_clange,
-    LAPACKE_clange_work,
-    LAPACKE_clanhe,
-    LAPACKE_clanhe_work,
-    LAPACKE_clansy,
-    LAPACKE_clansy_work,
-    LAPACKE_clantr,
-    LAPACKE_clantr_work,
-    LAPACKE_clapmr,
-    LAPACKE_clapmr_work,
-    LAPACKE_clarfb,
-    LAPACKE_clarfb_work,
-    LAPACKE_clarfg,
-    LAPACKE_clarfg_work,
-    LAPACKE_clarft,
-    LAPACKE_clarft_work,
-    LAPACKE_clarfx,
-    LAPACKE_clarfx_work,
-    LAPACKE_clarnv,
-    LAPACKE_clarnv_work,
-    LAPACKE_claset,
-    LAPACKE_claset_work,
-    LAPACKE_claswp,
-    LAPACKE_claswp_work,
-    LAPACKE_clauum,
-    LAPACKE_clauum_work,
-    LAPACKE_cpbcon,
-    LAPACKE_cpbcon_work,
-    LAPACKE_cpbequ,
-    LAPACKE_cpbequ_work,
-    LAPACKE_cpbrfs,
-    LAPACKE_cpbrfs_work,
-    LAPACKE_cpbstf,
-    LAPACKE_cpbstf_work,
-    LAPACKE_cpbsv,
-    LAPACKE_cpbsv_work,
-    LAPACKE_cpbsvx,
-    LAPACKE_cpbsvx_work,
-    LAPACKE_cpbtrf,
-    LAPACKE_cpbtrf_work,
-    LAPACKE_cpbtrs,
-    LAPACKE_cpbtrs_work,
-    LAPACKE_cpftrf,
-    LAPACKE_cpftrf_work,
-    LAPACKE_cpftri,
-    LAPACKE_cpftri_work,
-    LAPACKE_cpftrs,
-    LAPACKE_cpftrs_work,
-    LAPACKE_cpocon,
-    LAPACKE_cpocon_work,
-    LAPACKE_cpoequ,
-    LAPACKE_cpoequ_work,
-    LAPACKE_cpoequb,
-    LAPACKE_cpoequb_work,
-    LAPACKE_cporfs,
-    LAPACKE_cporfs_work,
-    LAPACKE_cposv,
-    LAPACKE_cposv_work,
-    LAPACKE_cposvx,
-    LAPACKE_cposvx_work,
-    LAPACKE_cpotrf,
-    LAPACKE_cpotrf_work,
-    LAPACKE_cpotri,
-    LAPACKE_cpotri_work,
-    LAPACKE_cpotrs,
-    LAPACKE_cpotrs_work,
-    LAPACKE_cppcon,
-    LAPACKE_cppcon_work,
-    LAPACKE_cppequ,
-    LAPACKE_cppequ_work,
-    LAPACKE_cpprfs,
-    LAPACKE_cpprfs_work,
-    LAPACKE_cppsv,
-    LAPACKE_cppsv_work,
-    LAPACKE_cppsvx,
-    LAPACKE_cppsvx_work,
-    LAPACKE_cpptrf,
-    LAPACKE_cpptrf_work,
-    LAPACKE_cpptri,
-    LAPACKE_cpptri_work,
-    LAPACKE_cpptrs,
-    LAPACKE_cpptrs_work,
-    LAPACKE_cpstrf,
-    LAPACKE_cpstrf_work,
-    LAPACKE_cptcon,
-    LAPACKE_cptcon_work,
-    LAPACKE_cpteqr,
-    LAPACKE_cpteqr_work,
-    LAPACKE_cptrfs,
-    LAPACKE_cptrfs_work,
-    LAPACKE_cptsv,
-    LAPACKE_cptsv_work,
-    LAPACKE_cptsvx,
-    LAPACKE_cptsvx_work,
-    LAPACKE_cpttrf,
-    LAPACKE_cpttrf_work,
-    LAPACKE_cpttrs,
-    LAPACKE_cpttrs_work,
-    LAPACKE_cspcon,
-    LAPACKE_cspcon_work,
-    LAPACKE_csprfs,
-    LAPACKE_csprfs_work,
-    LAPACKE_cspsv,
-    LAPACKE_cspsv_work,
-    LAPACKE_cspsvx,
-    LAPACKE_cspsvx_work,
-    LAPACKE_csptrf,
-    LAPACKE_csptrf_work,
-    LAPACKE_csptri,
-    LAPACKE_csptri_work,
-    LAPACKE_csptrs,
-    LAPACKE_csptrs_work,
-    LAPACKE_cstedc,
-    LAPACKE_cstedc_work,
-    LAPACKE_cstegr,
-    LAPACKE_cstegr_work,
-    LAPACKE_cstein,
-    LAPACKE_cstein_work,
-    LAPACKE_cstemr,
-    LAPACKE_cstemr_work,
-    LAPACKE_csteqr,
-    LAPACKE_csteqr_work,
-    LAPACKE_csycon,
-    LAPACKE_csycon_work,
-    LAPACKE_csyconv,
-    LAPACKE_csyconv_work,
-    LAPACKE_csyequb,
-    LAPACKE_csyequb_work,
-    LAPACKE_csyrfs,
-    LAPACKE_csyrfs_work,
-    LAPACKE_csysv,
-    LAPACKE_csysv_rook,
-    LAPACKE_csysv_rook_work,
-    LAPACKE_csysv_work,
-    LAPACKE_csysvx,
-    LAPACKE_csysvx_work,
-    LAPACKE_csyswapr,
-    LAPACKE_csyswapr_work,
-    LAPACKE_csytrf,
-    LAPACKE_csytrf_work,
-    LAPACKE_csytri,
-    LAPACKE_csytri2,
-    LAPACKE_csytri2_work,
-    LAPACKE_csytri2x,
-    LAPACKE_csytri2x_work,
-    LAPACKE_csytri_work,
-    LAPACKE_csytrs,
-    LAPACKE_csytrs2,
-    LAPACKE_csytrs2_work,
-    LAPACKE_csytrs_work,
-    LAPACKE_ctbcon,
-    LAPACKE_ctbcon_work,
-    LAPACKE_ctbrfs,
-    LAPACKE_ctbrfs_work,
-    LAPACKE_ctbtrs,
-    LAPACKE_ctbtrs_work,
-    LAPACKE_ctfsm,
-    LAPACKE_ctfsm_work,
-    LAPACKE_ctftri,
-    LAPACKE_ctftri_work,
-    LAPACKE_ctfttp,
-    LAPACKE_ctfttp_work,
-    LAPACKE_ctfttr,
-    LAPACKE_ctfttr_work,
-    LAPACKE_ctgevc,
-    LAPACKE_ctgevc_work,
-    LAPACKE_ctgexc,
-    LAPACKE_ctgexc_work,
-    LAPACKE_ctgsen,
-    LAPACKE_ctgsen_work,
-    LAPACKE_ctgsja,
-    LAPACKE_ctgsja_work,
-    LAPACKE_ctgsna,
-    LAPACKE_ctgsna_work,
-    LAPACKE_ctgsyl,
-    LAPACKE_ctgsyl_work,
-    LAPACKE_ctpcon,
-    LAPACKE_ctpcon_work,
-    LAPACKE_ctpmqrt,
-    LAPACKE_ctpmqrt_work,
-    LAPACKE_ctpqrt,
-    LAPACKE_ctpqrt2,
-    LAPACKE_ctpqrt2_work,
-    LAPACKE_ctpqrt_work,
-    LAPACKE_ctprfb,
-    LAPACKE_ctprfb_work,
-    LAPACKE_ctprfs,
-    LAPACKE_ctprfs_work,
-    LAPACKE_ctptri,
-    LAPACKE_ctptri_work,
-    LAPACKE_ctptrs,
-    LAPACKE_ctptrs_work,
-    LAPACKE_ctpttf,
-    LAPACKE_ctpttf_work,
-    LAPACKE_ctpttr,
-    LAPACKE_ctpttr_work,
-    LAPACKE_ctrcon,
-    LAPACKE_ctrcon_work,
-    LAPACKE_ctrevc,
-    LAPACKE_ctrevc_work,
-    LAPACKE_ctrexc,
-    LAPACKE_ctrexc_work,
-    LAPACKE_ctrrfs,
-    LAPACKE_ctrrfs_work,
-    LAPACKE_ctrsen,
-    LAPACKE_ctrsen_work,
-    LAPACKE_ctrsna,
-    LAPACKE_ctrsna_work,
-    LAPACKE_ctrsyl,
-    LAPACKE_ctrsyl_work,
-    LAPACKE_ctrtri,
-    LAPACKE_ctrtri_work,
-    LAPACKE_ctrtrs,
-    LAPACKE_ctrtrs_work,
-    LAPACKE_ctrttf,
-    LAPACKE_ctrttf_work,
-    LAPACKE_ctrttp,
-    LAPACKE_ctrttp_work,
-    LAPACKE_ctzrzf,
-    LAPACKE_ctzrzf_work,
-    LAPACKE_cunbdb,
-    LAPACKE_cunbdb_work,
-    LAPACKE_cuncsd,
-    LAPACKE_cuncsd_work,
-    LAPACKE_cungbr,
-    LAPACKE_cungbr_work,
-    LAPACKE_cunghr,
-    LAPACKE_cunghr_work,
-    LAPACKE_cunglq,
-    LAPACKE_cunglq_work,
-    LAPACKE_cungql,
-    LAPACKE_cungql_work,
-    LAPACKE_cungqr,
-    LAPACKE_cungqr_work,
-    LAPACKE_cungrq,
-    LAPACKE_cungrq_work,
-    LAPACKE_cungtr,
-    LAPACKE_cungtr_work,
-    LAPACKE_cunmbr,
-    LAPACKE_cunmbr_work,
-    LAPACKE_cunmhr,
-    LAPACKE_cunmhr_work,
-    LAPACKE_cunmlq,
-    LAPACKE_cunmlq_work,
-    LAPACKE_cunmql,
-    LAPACKE_cunmql_work,
-    LAPACKE_cunmqr,
-    LAPACKE_cunmqr_work,
-    LAPACKE_cunmrq,
-    LAPACKE_cunmrq_work,
-    LAPACKE_cunmrz,
-    LAPACKE_cunmrz_work,
-    LAPACKE_cunmtr,
-    LAPACKE_cunmtr_work,
-    LAPACKE_cupgtr,
-    LAPACKE_cupgtr_work,
-    LAPACKE_cupmtr,
-    LAPACKE_cupmtr_work,
-    LAPACKE_csyr,
-    LAPACKE_csyr_work,
-    LAPACKE_clatms,
-    LAPACKE_clatms_work,
-    LAPACKE_clagge,
-    LAPACKE_clagge_work,
-    LAPACKE_claghe,
-    LAPACKE_claghe_work,
-    LAPACKE_clagsy,
-    LAPACKE_clagsy_work,
-    LAPACKE_cgejsv,
-    LAPACKE_cgejsv_work,
-    LAPACKE_cgesvdx,
-    LAPACKE_cgesvdx_work,
-    LAPACKE_cgesvj,
-    LAPACKE_cgesvj_work,
-    LAPACKE_cgetrf2,
-    LAPACKE_cgetrf2_work,
-    LAPACKE_cgges3,
-    LAPACKE_cgges3_work,
-    LAPACKE_cggev3,
-    LAPACKE_cggev3_work,
-    LAPACKE_cgghd3,
-    LAPACKE_cgghd3_work,
-    LAPACKE_cggsvd3,
-    LAPACKE_cggsvd3_work,
-    LAPACKE_cggsvp3,
-    LAPACKE_cggsvp3_work,
-    LAPACKE_chetrf_rook,
-    LAPACKE_chetrf_rook_work,
-    LAPACKE_chetrs_rook,
-    LAPACKE_chetrs_rook_work,
-    LAPACKE_clapmt,
-    LAPACKE_clapmt_work,
-    LAPACKE_clascl,
-    LAPACKE_clascl_work,
-    LAPACKE_cpotrf2,
-    LAPACKE_cpotrf2_work,
-    LAPACKE_csytrf_rook,
-    LAPACKE_csytrf_rook_work,
-    LAPACKE_csytrs_rook,
-    LAPACKE_csytrs_rook_work,
-    LAPACKE_cuncsd2by1,
-    LAPACKE_cuncsd2by1_work,
-    LAPACKE_cgelq,
-    LAPACKE_cgelq_work,
-    LAPACKE_cgemlq,
-    LAPACKE_cgemlq_work,
-    LAPACKE_cgemqr,
-    LAPACKE_cgemqr_work,
-    LAPACKE_cgeqr,
-    LAPACKE_cgeqr_work,
-    LAPACKE_cgetsls,
-    LAPACKE_cgetsls_work,
-    LAPACKE_chbev_2stage,
-    LAPACKE_chbev_2stage_work,
-    LAPACKE_chbevd_2stage,
-    LAPACKE_chbevd_2stage_work,
-    LAPACKE_chbevx_2stage,
-    LAPACKE_chbevx_2stage_work,
-    LAPACKE_checon_3,
-    LAPACKE_checon_3_work,
-    LAPACKE_cheev_2stage,
-    LAPACKE_cheev_2stage_work,
-    LAPACKE_cheevd_2stage,
-    LAPACKE_cheevd_2stage_work,
-    LAPACKE_cheevr_2stage,
-    LAPACKE_cheevr_2stage_work,
-    LAPACKE_cheevx_2stage,
-    LAPACKE_cheevx_2stage_work,
-    LAPACKE_chegv_2stage,
-    LAPACKE_chegv_2stage_work,
-    LAPACKE_chesv_aa,
-    LAPACKE_chesv_aa_work,
-    LAPACKE_chesv_rk,
-    LAPACKE_chesv_rk_work,
-    LAPACKE_chetrf_aa,
-    LAPACKE_chetrf_aa_work,
-    LAPACKE_chetrf_rk,
-    LAPACKE_chetrf_rk_work,
-    LAPACKE_chetri_3,
-    LAPACKE_chetri_3_work,
-    LAPACKE_chetrs_aa,
-    LAPACKE_chetrs_aa_work,
-    LAPACKE_chetrs_3,
-    LAPACKE_chetrs_3_work,
-    LAPACKE_csycon_3,
-    LAPACKE_csycon_3_work,
-    LAPACKE_csysv_aa,
-    LAPACKE_csysv_aa_work,
-    LAPACKE_csysv_rk,
-    LAPACKE_csysv_rk_work,
-    LAPACKE_csytrf_aa,
-    LAPACKE_csytrf_aa_work,
-    LAPACKE_csytrf_rk,
-    LAPACKE_csytrf_rk_work,
-    LAPACKE_csytri_3,
-    LAPACKE_csytri_3_work,
-    LAPACKE_csytrs_aa,
-    LAPACKE_csytrs_aa_work,
-    LAPACKE_csytrs_3,
-    LAPACKE_csytrs_3_work,
-    LAPACKE_chesv_aa_2stage,
-    LAPACKE_chesv_aa_2stage_work,
-    LAPACKE_chetrf_aa_2stage,
-    LAPACKE_chetrf_aa_2stage_work,
-    LAPACKE_chetrs_aa_2stage,
-    LAPACKE_chetrs_aa_2stage_work,
-    LAPACKE_clacrm,
-    LAPACKE_clacrm_work,
-    LAPACKE_clarcm,
-    LAPACKE_clarcm_work,
-    LAPACKE_classq,
-    LAPACKE_classq_work,
-    LAPACKE_csysv_aa_2stage,
-    LAPACKE_csysv_aa_2stage_work,
-    LAPACKE_csytrf_aa_2stage,
-    LAPACKE_csytrf_aa_2stage_work,
-    LAPACKE_csytrs_aa_2stage,
-    LAPACKE_csytrs_aa_2stage_work,
-);
-@lapackeobjsd = (
-    LAPACKE_dgb_nancheck,
-    LAPACKE_dgb_trans,
-    LAPACKE_dge_nancheck,
-    LAPACKE_dge_trans,
-    LAPACKE_dgg_nancheck,
-    LAPACKE_dgg_trans,
-    LAPACKE_dgt_nancheck,
-    LAPACKE_dhs_nancheck,
-    LAPACKE_dhs_trans,
-    LAPACKE_d_nancheck,
-    LAPACKE_dpb_nancheck,
-    LAPACKE_dpb_trans,
-    LAPACKE_dpf_nancheck,
-    LAPACKE_dpf_trans,
-    LAPACKE_dpo_nancheck,
-    LAPACKE_dpo_trans,
-    LAPACKE_dpp_nancheck,
-    LAPACKE_dpp_trans,
-    LAPACKE_dpt_nancheck,
-    LAPACKE_dsb_nancheck,
-    LAPACKE_dsb_trans,
-    LAPACKE_dsp_nancheck,
-    LAPACKE_dsp_trans,
-    LAPACKE_dst_nancheck,
-    LAPACKE_dsy_nancheck,
-    LAPACKE_dsy_trans,
-    LAPACKE_dtb_nancheck,
-    LAPACKE_dtb_trans,
-    LAPACKE_dtf_nancheck,
-    LAPACKE_dtf_trans,
-    LAPACKE_dtp_nancheck,
-    LAPACKE_dtp_trans,
-    LAPACKE_dtr_nancheck,
-    LAPACKE_dtr_trans,
-    LAPACKE_dbbcsd,
-    LAPACKE_dbbcsd_work,
-    LAPACKE_dbdsdc,
-    LAPACKE_dbdsdc_work,
-    LAPACKE_dbdsqr,
-    LAPACKE_dbdsqr_work,
-    LAPACKE_ddisna,
-    LAPACKE_ddisna_work,
-    LAPACKE_dgbbrd,
-    LAPACKE_dgbbrd_work,
-    LAPACKE_dgbcon,
-    LAPACKE_dgbcon_work,
-    LAPACKE_dgbequ,
-    LAPACKE_dgbequ_work,
-    LAPACKE_dgbequb,
-    LAPACKE_dgbequb_work,
-    LAPACKE_dgbrfs,
-    LAPACKE_dgbrfs_work,
-    LAPACKE_dgbsv,
-    LAPACKE_dgbsv_work,
-    LAPACKE_dgbsvx,
-    LAPACKE_dgbsvx_work,
-    LAPACKE_dgbtrf,
-    LAPACKE_dgbtrf_work,
-    LAPACKE_dgbtrs,
-    LAPACKE_dgbtrs_work,
-    LAPACKE_dgebak,
-    LAPACKE_dgebak_work,
-    LAPACKE_dgebal,
-    LAPACKE_dgebal_work,
-    LAPACKE_dgebrd,
-    LAPACKE_dgebrd_work,
-    LAPACKE_dgecon,
-    LAPACKE_dgecon_work,
-    LAPACKE_dgeequ,
-    LAPACKE_dgeequ_work,
-    LAPACKE_dgeequb,
-    LAPACKE_dgeequb_work,
-    LAPACKE_dgees,
-    LAPACKE_dgees_work,
-    LAPACKE_dgeesx,
-    LAPACKE_dgeesx_work,
-    LAPACKE_dgeev,
-    LAPACKE_dgeev_work,
-    LAPACKE_dgeevx,
-    LAPACKE_dgeevx_work,
-    LAPACKE_dgehrd,
-    LAPACKE_dgehrd_work,
-    LAPACKE_dgejsv,
-    LAPACKE_dgejsv_work,
-    LAPACKE_dgelq2,
-    LAPACKE_dgelq2_work,
-    LAPACKE_dgelqf,
-    LAPACKE_dgelqf_work,
-    LAPACKE_dgels,
-    LAPACKE_dgels_work,
-    LAPACKE_dgelsd,
-    LAPACKE_dgelsd_work,
-    LAPACKE_dgelss,
-    LAPACKE_dgelss_work,
-    LAPACKE_dgelsy,
-    LAPACKE_dgelsy_work,
-    LAPACKE_dgemqrt,
-    LAPACKE_dgemqrt_work,
-    LAPACKE_dgeqlf,
-    LAPACKE_dgeqlf_work,
-    LAPACKE_dgeqp3,
-    LAPACKE_dgeqp3_work,
-    LAPACKE_dgeqr2,
-    LAPACKE_dgeqr2_work,
-    LAPACKE_dgeqrf,
-    LAPACKE_dgeqrf_work,
-    LAPACKE_dgeqrfp,
-    LAPACKE_dgeqrfp_work,
-    LAPACKE_dgeqrt,
-    LAPACKE_dgeqrt2,
-    LAPACKE_dgeqrt2_work,
-    LAPACKE_dgeqrt3,
-    LAPACKE_dgeqrt3_work,
-    LAPACKE_dgeqrt_work,
-    LAPACKE_dgerfs,
-    LAPACKE_dgerfs_work,
-    LAPACKE_dgerqf,
-    LAPACKE_dgerqf_work,
-    LAPACKE_dgesdd,
-    LAPACKE_dgesdd_work,
-    LAPACKE_dgesv,
-    LAPACKE_dgesv_work,
-    LAPACKE_dgesvd,
-    LAPACKE_dgesvd_work,
-    LAPACKE_dgesvj,
-    LAPACKE_dgesvj_work,
-    LAPACKE_dgesvx,
-    LAPACKE_dgesvx_work,
-    LAPACKE_dgetf2,
-    LAPACKE_dgetf2_work,
-    LAPACKE_dgetrf,
-    LAPACKE_dgetrf_work,
-    LAPACKE_dgetri,
-    LAPACKE_dgetri_work,
-    LAPACKE_dgetrs,
-    LAPACKE_dgetrs_work,
-    LAPACKE_dggbak,
-    LAPACKE_dggbak_work,
-    LAPACKE_dggbal,
-    LAPACKE_dggbal_work,
-    LAPACKE_dgges,
-    LAPACKE_dgges_work,
-    LAPACKE_dggesx,
-    LAPACKE_dggesx_work,
-    LAPACKE_dggev,
-    LAPACKE_dggev_work,
-    LAPACKE_dggevx,
-    LAPACKE_dggevx_work,
-    LAPACKE_dggglm,
-    LAPACKE_dggglm_work,
-    LAPACKE_dgghrd,
-    LAPACKE_dgghrd_work,
-    LAPACKE_dgglse,
-    LAPACKE_dgglse_work,
-    LAPACKE_dggqrf,
-    LAPACKE_dggqrf_work,
-    LAPACKE_dggrqf,
-    LAPACKE_dggrqf_work,
-    LAPACKE_dgtcon,
-    LAPACKE_dgtcon_work,
-    LAPACKE_dgtrfs,
-    LAPACKE_dgtrfs_work,
-    LAPACKE_dgtsv,
-    LAPACKE_dgtsv_work,
-    LAPACKE_dgtsvx,
-    LAPACKE_dgtsvx_work,
-    LAPACKE_dgttrf,
-    LAPACKE_dgttrf_work,
-    LAPACKE_dgttrs,
-    LAPACKE_dgttrs_work,
-    LAPACKE_dhgeqz,
-    LAPACKE_dhgeqz_work,
-    LAPACKE_dhsein,
-    LAPACKE_dhsein_work,
-    LAPACKE_dhseqr,
-    LAPACKE_dhseqr_work,
-    LAPACKE_dlacn2,
-    LAPACKE_dlacn2_work,
-    LAPACKE_dlacpy,
-    LAPACKE_dlacpy_work,
-    LAPACKE_dlag2s,
-    LAPACKE_dlag2s_work,
-    LAPACKE_dlamch,
-    LAPACKE_dlamch_work,
-    LAPACKE_dlange,
-    LAPACKE_dlange_work,
-    LAPACKE_dlansy,
-    LAPACKE_dlansy_work,
-    LAPACKE_dlantr,
-    LAPACKE_dlantr_work,
-    LAPACKE_dlapmr,
-    LAPACKE_dlapmr_work,
-    LAPACKE_dlapy2,
-    LAPACKE_dlapy2_work,
-    LAPACKE_dlapy3,
-    LAPACKE_dlapy3_work,
-    LAPACKE_dlarfb,
-    LAPACKE_dlarfb_work,
-    LAPACKE_dlarfg,
-    LAPACKE_dlarfg_work,
-    LAPACKE_dlarft,
-    LAPACKE_dlarft_work,
-    LAPACKE_dlarfx,
-    LAPACKE_dlarfx_work,
-    LAPACKE_dlarnv,
-    LAPACKE_dlarnv_work,
-    LAPACKE_dlartgp,
-    LAPACKE_dlartgp_work,
-    LAPACKE_dlartgs,
-    LAPACKE_dlartgs_work,
-    LAPACKE_dlaset,
-    LAPACKE_dlaset_work,
-    LAPACKE_dlasrt,
-    LAPACKE_dlasrt_work,
-    LAPACKE_dlaswp,
-    LAPACKE_dlaswp_work,
-    LAPACKE_dlauum,
-    LAPACKE_dlauum_work,
-    LAPACKE_dopgtr,
-    LAPACKE_dopgtr_work,
-    LAPACKE_dopmtr,
-    LAPACKE_dopmtr_work,
-    LAPACKE_dorbdb,
-    LAPACKE_dorbdb_work,
-    LAPACKE_dorcsd,
-    LAPACKE_dorcsd_work,
-    LAPACKE_dorgbr,
-    LAPACKE_dorgbr_work,
-    LAPACKE_dorghr,
-    LAPACKE_dorghr_work,
-    LAPACKE_dorglq,
-    LAPACKE_dorglq_work,
-    LAPACKE_dorgql,
-    LAPACKE_dorgql_work,
-    LAPACKE_dorgqr,
-    LAPACKE_dorgqr_work,
-    LAPACKE_dorgrq,
-    LAPACKE_dorgrq_work,
-    LAPACKE_dorgtr,
-    LAPACKE_dorgtr_work,
-    LAPACKE_dormbr,
-    LAPACKE_dormbr_work,
-    LAPACKE_dormhr,
-    LAPACKE_dormhr_work,
-    LAPACKE_dormlq,
-    LAPACKE_dormlq_work,
-    LAPACKE_dormql,
-    LAPACKE_dormql_work,
-    LAPACKE_dormqr,
-    LAPACKE_dormqr_work,
-    LAPACKE_dormrq,
-    LAPACKE_dormrq_work,
-    LAPACKE_dormrz,
-    LAPACKE_dormrz_work,
-    LAPACKE_dormtr,
-    LAPACKE_dormtr_work,
-    LAPACKE_dpbcon,
-    LAPACKE_dpbcon_work,
-    LAPACKE_dpbequ,
-    LAPACKE_dpbequ_work,
-    LAPACKE_dpbrfs,
-    LAPACKE_dpbrfs_work,
-    LAPACKE_dpbstf,
-    LAPACKE_dpbstf_work,
-    LAPACKE_dpbsv,
-    LAPACKE_dpbsv_work,
-    LAPACKE_dpbsvx,
-    LAPACKE_dpbsvx_work,
-    LAPACKE_dpbtrf,
-    LAPACKE_dpbtrf_work,
-    LAPACKE_dpbtrs,
-    LAPACKE_dpbtrs_work,
-    LAPACKE_dpftrf,
-    LAPACKE_dpftrf_work,
-    LAPACKE_dpftri,
-    LAPACKE_dpftri_work,
-    LAPACKE_dpftrs,
-    LAPACKE_dpftrs_work,
-    LAPACKE_dpocon,
-    LAPACKE_dpocon_work,
-    LAPACKE_dpoequ,
-    LAPACKE_dpoequ_work,
-    LAPACKE_dpoequb,
-    LAPACKE_dpoequb_work,
-    LAPACKE_dporfs,
-    LAPACKE_dporfs_work,
-    LAPACKE_dposv,
-    LAPACKE_dposv_work,
-    LAPACKE_dposvx,
-    LAPACKE_dposvx_work,
-    LAPACKE_dpotrf,
-    LAPACKE_dpotrf_work,
-    LAPACKE_dpotri,
-    LAPACKE_dpotri_work,
-    LAPACKE_dpotrs,
-    LAPACKE_dpotrs_work,
-    LAPACKE_dppcon,
-    LAPACKE_dppcon_work,
-    LAPACKE_dppequ,
-    LAPACKE_dppequ_work,
-    LAPACKE_dpprfs,
-    LAPACKE_dpprfs_work,
-    LAPACKE_dppsv,
-    LAPACKE_dppsv_work,
-    LAPACKE_dppsvx,
-    LAPACKE_dppsvx_work,
-    LAPACKE_dpptrf,
-    LAPACKE_dpptrf_work,
-    LAPACKE_dpptri,
-    LAPACKE_dpptri_work,
-    LAPACKE_dpptrs,
-    LAPACKE_dpptrs_work,
-    LAPACKE_dpstrf,
-    LAPACKE_dpstrf_work,
-    LAPACKE_dptcon,
-    LAPACKE_dptcon_work,
-    LAPACKE_dpteqr,
-    LAPACKE_dpteqr_work,
-    LAPACKE_dptrfs,
-    LAPACKE_dptrfs_work,
-    LAPACKE_dptsv,
-    LAPACKE_dptsv_work,
-    LAPACKE_dptsvx,
-    LAPACKE_dptsvx_work,
-    LAPACKE_dpttrf,
-    LAPACKE_dpttrf_work,
-    LAPACKE_dpttrs,
-    LAPACKE_dpttrs_work,
-    LAPACKE_dsbev,
-    LAPACKE_dsbev_work,
-    LAPACKE_dsbevd,
-    LAPACKE_dsbevd_work,
-    LAPACKE_dsbevx,
-    LAPACKE_dsbevx_work,
-    LAPACKE_dsbgst,
-    LAPACKE_dsbgst_work,
-    LAPACKE_dsbgv,
-    LAPACKE_dsbgv_work,
-    LAPACKE_dsbgvd,
-    LAPACKE_dsbgvd_work,
-    LAPACKE_dsbgvx,
-    LAPACKE_dsbgvx_work,
-    LAPACKE_dsbtrd,
-    LAPACKE_dsbtrd_work,
-    LAPACKE_dsfrk,
-    LAPACKE_dsfrk_work,
-    LAPACKE_dsgesv,
-    LAPACKE_dsgesv_work,
-    LAPACKE_dspcon,
-    LAPACKE_dspcon_work,
-    LAPACKE_dspev,
-    LAPACKE_dspev_work,
-    LAPACKE_dspevd,
-    LAPACKE_dspevd_work,
-    LAPACKE_dspevx,
-    LAPACKE_dspevx_work,
-    LAPACKE_dspgst,
-    LAPACKE_dspgst_work,
-    LAPACKE_dspgv,
-    LAPACKE_dspgv_work,
-    LAPACKE_dspgvd,
-    LAPACKE_dspgvd_work,
-    LAPACKE_dspgvx,
-    LAPACKE_dspgvx_work,
-    LAPACKE_dsposv,
-    LAPACKE_dsposv_work,
-    LAPACKE_dsprfs,
-    LAPACKE_dsprfs_work,
-    LAPACKE_dspsv,
-    LAPACKE_dspsv_work,
-    LAPACKE_dspsvx,
-    LAPACKE_dspsvx_work,
-    LAPACKE_dsptrd,
-    LAPACKE_dsptrd_work,
-    LAPACKE_dsptrf,
-    LAPACKE_dsptrf_work,
-    LAPACKE_dsptri,
-    LAPACKE_dsptri_work,
-    LAPACKE_dsptrs,
-    LAPACKE_dsptrs_work,
-    LAPACKE_dstebz,
-    LAPACKE_dstebz_work,
-    LAPACKE_dstedc,
-    LAPACKE_dstedc_work,
-    LAPACKE_dstegr,
-    LAPACKE_dstegr_work,
-    LAPACKE_dstein,
-    LAPACKE_dstein_work,
-    LAPACKE_dstemr,
-    LAPACKE_dstemr_work,
-    LAPACKE_dsteqr,
-    LAPACKE_dsteqr_work,
-    LAPACKE_dsterf,
-    LAPACKE_dsterf_work,
-    LAPACKE_dstev,
-    LAPACKE_dstev_work,
-    LAPACKE_dstevd,
-    LAPACKE_dstevd_work,
-    LAPACKE_dstevr,
-    LAPACKE_dstevr_work,
-    LAPACKE_dstevx,
-    LAPACKE_dstevx_work,
-    LAPACKE_dsycon,
-    LAPACKE_dsycon_work,
-    LAPACKE_dsyconv,
-    LAPACKE_dsyconv_work,
-    LAPACKE_dsyequb,
-    LAPACKE_dsyequb_work,
-    LAPACKE_dsyev,
-    LAPACKE_dsyev_work,
-    LAPACKE_dsyevd,
-    LAPACKE_dsyevd_work,
-    LAPACKE_dsyevr,
-    LAPACKE_dsyevr_work,
-    LAPACKE_dsyevx,
-    LAPACKE_dsyevx_work,
-    LAPACKE_dsygst,
-    LAPACKE_dsygst_work,
-    LAPACKE_dsygv,
-    LAPACKE_dsygv_work,
-    LAPACKE_dsygvd,
-    LAPACKE_dsygvd_work,
-    LAPACKE_dsygvx,
-    LAPACKE_dsygvx_work,
-    LAPACKE_dsyrfs,
-    LAPACKE_dsyrfs_work,
-    LAPACKE_dsysv,
-    LAPACKE_dsysv_rook,
-    LAPACKE_dsysv_rook_work,
-    LAPACKE_dsysv_work,
-    LAPACKE_dsysvx,
-    LAPACKE_dsysvx_work,
-    LAPACKE_dsyswapr,
-    LAPACKE_dsyswapr_work,
-    LAPACKE_dsytrd,
-    LAPACKE_dsytrd_work,
-    LAPACKE_dsytrf,
-    LAPACKE_dsytrf_work,
-    LAPACKE_dsytri,
-    LAPACKE_dsytri2,
-    LAPACKE_dsytri2_work,
-    LAPACKE_dsytri2x,
-    LAPACKE_dsytri2x_work,
-    LAPACKE_dsytri_work,
-    LAPACKE_dsytrs,
-    LAPACKE_dsytrs2,
-    LAPACKE_dsytrs2_work,
-    LAPACKE_dsytrs_work,
-    LAPACKE_dtbcon,
-    LAPACKE_dtbcon_work,
-    LAPACKE_dtbrfs,
-    LAPACKE_dtbrfs_work,
-    LAPACKE_dtbtrs,
-    LAPACKE_dtbtrs_work,
-    LAPACKE_dtfsm,
-    LAPACKE_dtfsm_work,
-    LAPACKE_dtftri,
-    LAPACKE_dtftri_work,
-    LAPACKE_dtfttp,
-    LAPACKE_dtfttp_work,
-    LAPACKE_dtfttr,
-    LAPACKE_dtfttr_work,
-    LAPACKE_dtgevc,
-    LAPACKE_dtgevc_work,
-    LAPACKE_dtgexc,
-    LAPACKE_dtgexc_work,
-    LAPACKE_dtgsen,
-    LAPACKE_dtgsen_work,
-    LAPACKE_dtgsja,
-    LAPACKE_dtgsja_work,
-    LAPACKE_dtgsna,
-    LAPACKE_dtgsna_work,
-    LAPACKE_dtgsyl,
-    LAPACKE_dtgsyl_work,
-    LAPACKE_dtpcon,
-    LAPACKE_dtpcon_work,
-    LAPACKE_dtpmqrt,
-    LAPACKE_dtpmqrt_work,
-    LAPACKE_dtpqrt,
-    LAPACKE_dtpqrt2,
-    LAPACKE_dtpqrt2_work,
-    LAPACKE_dtpqrt_work,
-    LAPACKE_dtprfb,
-    LAPACKE_dtprfb_work,
-    LAPACKE_dtprfs,
-    LAPACKE_dtprfs_work,
-    LAPACKE_dtptri,
-    LAPACKE_dtptri_work,
-    LAPACKE_dtptrs,
-    LAPACKE_dtptrs_work,
-    LAPACKE_dtpttf,
-    LAPACKE_dtpttf_work,
-    LAPACKE_dtpttr,
-    LAPACKE_dtpttr_work,
-    LAPACKE_dtrcon,
-    LAPACKE_dtrcon_work,
-    LAPACKE_dtrevc,
-    LAPACKE_dtrevc_work,
-    LAPACKE_dtrexc,
-    LAPACKE_dtrexc_work,
-    LAPACKE_dtrrfs,
-    LAPACKE_dtrrfs_work,
-    LAPACKE_dtrsen,
-    LAPACKE_dtrsen_work,
-    LAPACKE_dtrsna,
-    LAPACKE_dtrsna_work,
-    LAPACKE_dtrsyl,
-    LAPACKE_dtrsyl_work,
-    LAPACKE_dtrtri,
-    LAPACKE_dtrtri_work,
-    LAPACKE_dtrtrs,
-    LAPACKE_dtrtrs_work,
-    LAPACKE_dtrttf,
-    LAPACKE_dtrttf_work,
-    LAPACKE_dtrttp,
-    LAPACKE_dtrttp_work,
-    LAPACKE_dtzrzf,
-    LAPACKE_dtzrzf_work,
-    LAPACKE_dlatms,
-    LAPACKE_dlatms_work,
-    LAPACKE_dlagge,
-    LAPACKE_dlagge_work,
-    LAPACKE_dlagsy,
-    LAPACKE_dlagsy_work,
-    LAPACKE_dbdsvdx,
-    LAPACKE_dbdsvdx_work,
-    LAPACKE_dgesvdx,
-    LAPACKE_dgesvdx_work,
-    LAPACKE_dgetrf2,
-    LAPACKE_dgetrf2_work,
-    LAPACKE_dgges3,
-    LAPACKE_dgges3_work,
-    LAPACKE_dggev3,
-    LAPACKE_dggev3_work,
-    LAPACKE_dgghd3,
-    LAPACKE_dgghd3_work,
-    LAPACKE_dggsvd3,
-    LAPACKE_dggsvd3_work,
-    LAPACKE_dggsvp3,
-    LAPACKE_dggsvp3_work,
-    LAPACKE_dlapmt,
-    LAPACKE_dlapmt_work,
-    LAPACKE_dlascl,
-    LAPACKE_dlascl_work,
-    LAPACKE_dorcsd2by1,
-    LAPACKE_dorcsd2by1_work,
-    LAPACKE_dpotrf2,
-    LAPACKE_dpotrf2_work,
-    LAPACKE_dsytrf_rook,
-    LAPACKE_dsytrf_rook_work,
-    LAPACKE_dsytrs_rook,
-    LAPACKE_dsytrs_rook_work,
-    LAPACKE_dgelq,
-    LAPACKE_dgelq_work,
-    LAPACKE_dgemlq,
-    LAPACKE_dgemlq_work,
-    LAPACKE_dgemqr,
-    LAPACKE_dgemqr_work,
-    LAPACKE_dgeqr,
-    LAPACKE_dgeqr_work,
-    LAPACKE_dgetsls,
-    LAPACKE_dgetsls_work,
-    LAPACKE_dsbev_2stage,
-    LAPACKE_dsbev_2stage_work,
-    LAPACKE_dsbevd_2stage,
-    LAPACKE_dsbevd_2stage_work,
-    LAPACKE_dsbevx_2stage,
-    LAPACKE_dsbevx_2stage_work,
-    LAPACKE_dsycon_3,
-    LAPACKE_dsycon_3_work,
-    LAPACKE_dsyev_2stage,
-    LAPACKE_dsyev_2stage_work,
-    LAPACKE_dsyevd_2stage,
-    LAPACKE_dsyevd_2stage_work,
-    LAPACKE_dsyevr_2stage,
-    LAPACKE_dsyevr_2stage_work,
-    LAPACKE_dsyevx_2stage,
-    LAPACKE_dsyevx_2stage_work,
-    LAPACKE_dsygv_2stage,
-    LAPACKE_dsygv_2stage_work,
-    LAPACKE_dsysv_aa,
-    LAPACKE_dsysv_aa_work,
-    LAPACKE_dsysv_rk,
-    LAPACKE_dsysv_rk_work,
-    LAPACKE_dsytrf_aa,
-    LAPACKE_dsytrf_aa_work,
-    LAPACKE_dsytrf_rk,
-    LAPACKE_dsytrf_rk_work,
-    LAPACKE_dsytri_3,
-    LAPACKE_dsytri_3_work,
-    LAPACKE_dsytrs_aa,
-    LAPACKE_dsytrs_aa_work,
-    LAPACKE_dsytrs_3,
-    LAPACKE_dsytrs_3_work,
-    LAPACKE_dlassq,
-    LAPACKE_dlassq_work,
-    LAPACKE_dsysv_aa_2stage,
-    LAPACKE_dsysv_aa_2stage_work,
-    LAPACKE_dsytrf_aa_2stage,
-    LAPACKE_dsytrf_aa_2stage_work,
-    LAPACKE_dsytrs_aa_2stage,
-    LAPACKE_dsytrs_aa_2stage_work,
-    LAPACKE_dgesvdq,
-    LAPACKE_dgesvdq_work,
-    LAPACKE_slag2d,
-    LAPACKE_slag2d_work,
-);
-@lapackeobjss = (
-    LAPACKE_sgb_nancheck,
-    LAPACKE_sgb_trans,
-    LAPACKE_sge_nancheck,
-    LAPACKE_sge_trans,
-    LAPACKE_sgg_nancheck,
-    LAPACKE_sgg_trans,
-    LAPACKE_sgt_nancheck,
-    LAPACKE_shs_nancheck,
-    LAPACKE_shs_trans,
-    LAPACKE_s_nancheck,
-    LAPACKE_spb_nancheck,
-    LAPACKE_spb_trans,
-    LAPACKE_spf_nancheck,
-    LAPACKE_spf_trans,
-    LAPACKE_spo_nancheck,
-    LAPACKE_spo_trans,
-    LAPACKE_spp_nancheck,
-    LAPACKE_spp_trans,
-    LAPACKE_spt_nancheck,
-    LAPACKE_ssb_nancheck,
-    LAPACKE_ssb_trans,
-    LAPACKE_ssp_nancheck,
-    LAPACKE_ssp_trans,
-    LAPACKE_sst_nancheck,
-    LAPACKE_ssy_nancheck,
-    LAPACKE_ssy_trans,
-    LAPACKE_stb_nancheck,
-    LAPACKE_stb_trans,
-    LAPACKE_stf_nancheck,
-    LAPACKE_stf_trans,
-    LAPACKE_stp_nancheck,
-    LAPACKE_stp_trans,
-    LAPACKE_str_nancheck,
-    LAPACKE_str_trans,
-    LAPACKE_sbbcsd,
-    LAPACKE_sbbcsd_work,
-    LAPACKE_sbdsdc,
-    LAPACKE_sbdsdc_work,
-    LAPACKE_sbdsqr,
-    LAPACKE_sbdsqr_work,
-    LAPACKE_sdisna,
-    LAPACKE_sdisna_work,
-    LAPACKE_sgbbrd,
-    LAPACKE_sgbbrd_work,
-    LAPACKE_sgbcon,
-    LAPACKE_sgbcon_work,
-    LAPACKE_sgbequ,
-    LAPACKE_sgbequ_work,
-    LAPACKE_sgbequb,
-    LAPACKE_sgbequb_work,
-    LAPACKE_sgbrfs,
-    LAPACKE_sgbrfs_work,
-    LAPACKE_sgbsv,
-    LAPACKE_sgbsv_work,
-    LAPACKE_sgbsvx,
-    LAPACKE_sgbsvx_work,
-    LAPACKE_sgbtrf,
-    LAPACKE_sgbtrf_work,
-    LAPACKE_sgbtrs,
-    LAPACKE_sgbtrs_work,
-    LAPACKE_sgebak,
-    LAPACKE_sgebak_work,
-    LAPACKE_sgebal,
-    LAPACKE_sgebal_work,
-    LAPACKE_sgebrd,
-    LAPACKE_sgebrd_work,
-    LAPACKE_sgecon,
-    LAPACKE_sgecon_work,
-    LAPACKE_sgeequ,
-    LAPACKE_sgeequ_work,
-    LAPACKE_sgeequb,
-    LAPACKE_sgeequb_work,
-    LAPACKE_sgees,
-    LAPACKE_sgees_work,
-    LAPACKE_sgeesx,
-    LAPACKE_sgeesx_work,
-    LAPACKE_sgeev,
-    LAPACKE_sgeev_work,
-    LAPACKE_sgeevx,
-    LAPACKE_sgeevx_work,
-    LAPACKE_sgehrd,
-    LAPACKE_sgehrd_work,
-    LAPACKE_sgejsv,
-    LAPACKE_sgejsv_work,
-    LAPACKE_sgelq2,
-    LAPACKE_sgelq2_work,
-    LAPACKE_sgelqf,
-    LAPACKE_sgelqf_work,
-    LAPACKE_sgels,
-    LAPACKE_sgels_work,
-    LAPACKE_sgelsd,
-    LAPACKE_sgelsd_work,
-    LAPACKE_sgelss,
-    LAPACKE_sgelss_work,
-    LAPACKE_sgelsy,
-    LAPACKE_sgelsy_work,
-    LAPACKE_sgemqrt,
-    LAPACKE_sgemqrt_work,
-    LAPACKE_sgeqlf,
-    LAPACKE_sgeqlf_work,
-    LAPACKE_sgeqp3,
-    LAPACKE_sgeqp3_work,
-    LAPACKE_sgeqr2,
-    LAPACKE_sgeqr2_work,
-    LAPACKE_sgeqrf,
-    LAPACKE_sgeqrf_work,
-    LAPACKE_sgeqrfp,
-    LAPACKE_sgeqrfp_work,
-    LAPACKE_sgeqrt,
-    LAPACKE_sgeqrt2,
-    LAPACKE_sgeqrt2_work,
-    LAPACKE_sgeqrt3,
-    LAPACKE_sgeqrt3_work,
-    LAPACKE_sgeqrt_work,
-    LAPACKE_sgerfs,
-    LAPACKE_sgerfs_work,
-    LAPACKE_sgerqf,
-    LAPACKE_sgerqf_work,
-    LAPACKE_sgesdd,
-    LAPACKE_sgesdd_work,
-    LAPACKE_sgesv,
-    LAPACKE_sgesv_work,
-    LAPACKE_sgesvd,
-    LAPACKE_sgesvd_work,
-    LAPACKE_sgesvj,
-    LAPACKE_sgesvj_work,
-    LAPACKE_sgesvx,
-    LAPACKE_sgesvx_work,
-    LAPACKE_sgetf2,
-    LAPACKE_sgetf2_work,
-    LAPACKE_sgetrf,
-    LAPACKE_sgetrf_work,
-    LAPACKE_sgetri,
-    LAPACKE_sgetri_work,
-    LAPACKE_sgetrs,
-    LAPACKE_sgetrs_work,
-    LAPACKE_sggbak,
-    LAPACKE_sggbak_work,
-    LAPACKE_sggbal,
-    LAPACKE_sggbal_work,
-    LAPACKE_sgges,
-    LAPACKE_sgges_work,
-    LAPACKE_sggesx,
-    LAPACKE_sggesx_work,
-    LAPACKE_sggev,
-    LAPACKE_sggev_work,
-    LAPACKE_sggevx,
-    LAPACKE_sggevx_work,
-    LAPACKE_sggglm,
-    LAPACKE_sggglm_work,
-    LAPACKE_sgghrd,
-    LAPACKE_sgghrd_work,
-    LAPACKE_sgglse,
-    LAPACKE_sgglse_work,
-    LAPACKE_sggqrf,
-    LAPACKE_sggqrf_work,
-    LAPACKE_sggrqf,
-    LAPACKE_sggrqf_work,
-    LAPACKE_sgtcon,
-    LAPACKE_sgtcon_work,
-    LAPACKE_sgtrfs,
-    LAPACKE_sgtrfs_work,
-    LAPACKE_sgtsv,
-    LAPACKE_sgtsv_work,
-    LAPACKE_sgtsvx,
-    LAPACKE_sgtsvx_work,
-    LAPACKE_sgttrf,
-    LAPACKE_sgttrf_work,
-    LAPACKE_sgttrs,
-    LAPACKE_sgttrs_work,
-    LAPACKE_shgeqz,
-    LAPACKE_shgeqz_work,
-    LAPACKE_shsein,
-    LAPACKE_shsein_work,
-    LAPACKE_shseqr,
-    LAPACKE_shseqr_work,
-    LAPACKE_slacn2,
-    LAPACKE_slacn2_work,
-    LAPACKE_slacpy,
-    LAPACKE_slacpy_work,
-    LAPACKE_slamch,
-    LAPACKE_slamch_work,
-    LAPACKE_slange,
-    LAPACKE_slange_work,
-    LAPACKE_slansy,
-    LAPACKE_slansy_work,
-    LAPACKE_slantr,
-    LAPACKE_slantr_work,
-    LAPACKE_slapmr,
-    LAPACKE_slapmr_work,
-    LAPACKE_slapy2,
-    LAPACKE_slapy2_work,
-    LAPACKE_slapy3,
-    LAPACKE_slapy3_work,
-    LAPACKE_slarfb,
-    LAPACKE_slarfb_work,
-    LAPACKE_slarfg,
-    LAPACKE_slarfg_work,
-    LAPACKE_slarft,
-    LAPACKE_slarft_work,
-    LAPACKE_slarfx,
-    LAPACKE_slarfx_work,
-    LAPACKE_slarnv,
-    LAPACKE_slarnv_work,
-    LAPACKE_slartgp,
-    LAPACKE_slartgp_work,
-    LAPACKE_slartgs,
-    LAPACKE_slartgs_work,
-    LAPACKE_slaset,
-    LAPACKE_slaset_work,
-    LAPACKE_slasrt,
-    LAPACKE_slasrt_work,
-    LAPACKE_slaswp,
-    LAPACKE_slaswp_work,
-    LAPACKE_slauum,
-    LAPACKE_slauum_work,
-    LAPACKE_sopgtr,
-    LAPACKE_sopgtr_work,
-    LAPACKE_sopmtr,
-    LAPACKE_sopmtr_work,
-    LAPACKE_sorbdb,
-    LAPACKE_sorbdb_work,
-    LAPACKE_sorcsd,
-    LAPACKE_sorcsd_work,
-    LAPACKE_sorgbr,
-    LAPACKE_sorgbr_work,
-    LAPACKE_sorghr,
-    LAPACKE_sorghr_work,
-    LAPACKE_sorglq,
-    LAPACKE_sorglq_work,
-    LAPACKE_sorgql,
-    LAPACKE_sorgql_work,
-    LAPACKE_sorgqr,
-    LAPACKE_sorgqr_work,
-    LAPACKE_sorgrq,
-    LAPACKE_sorgrq_work,
-    LAPACKE_sorgtr,
-    LAPACKE_sorgtr_work,
-    LAPACKE_sormbr,
-    LAPACKE_sormbr_work,
-    LAPACKE_sormhr,
-    LAPACKE_sormhr_work,
-    LAPACKE_sormlq,
-    LAPACKE_sormlq_work,
-    LAPACKE_sormql,
-    LAPACKE_sormql_work,
-    LAPACKE_sormqr,
-    LAPACKE_sormqr_work,
-    LAPACKE_sormrq,
-    LAPACKE_sormrq_work,
-    LAPACKE_sormrz,
-    LAPACKE_sormrz_work,
-    LAPACKE_sormtr,
-    LAPACKE_sormtr_work,
-    LAPACKE_spbcon,
-    LAPACKE_spbcon_work,
-    LAPACKE_spbequ,
-    LAPACKE_spbequ_work,
-    LAPACKE_spbrfs,
-    LAPACKE_spbrfs_work,
-    LAPACKE_spbstf,
-    LAPACKE_spbstf_work,
-    LAPACKE_spbsv,
-    LAPACKE_spbsv_work,
-    LAPACKE_spbsvx,
-    LAPACKE_spbsvx_work,
-    LAPACKE_spbtrf,
-    LAPACKE_spbtrf_work,
-    LAPACKE_spbtrs,
-    LAPACKE_spbtrs_work,
-    LAPACKE_spftrf,
-    LAPACKE_spftrf_work,
-    LAPACKE_spftri,
-    LAPACKE_spftri_work,
-    LAPACKE_spftrs,
-    LAPACKE_spftrs_work,
-    LAPACKE_spocon,
-    LAPACKE_spocon_work,
-    LAPACKE_spoequ,
-    LAPACKE_spoequ_work,
-    LAPACKE_spoequb,
-    LAPACKE_spoequb_work,
-    LAPACKE_sporfs,
-    LAPACKE_sporfs_work,
-    LAPACKE_sposv,
-    LAPACKE_sposv_work,
-    LAPACKE_sposvx,
-    LAPACKE_sposvx_work,
-    LAPACKE_spotrf,
-    LAPACKE_spotrf_work,
-    LAPACKE_spotri,
-    LAPACKE_spotri_work,
-    LAPACKE_spotrs,
-    LAPACKE_spotrs_work,
-    LAPACKE_sppcon,
-    LAPACKE_sppcon_work,
-    LAPACKE_sppequ,
-    LAPACKE_sppequ_work,
-    LAPACKE_spprfs,
-    LAPACKE_spprfs_work,
-    LAPACKE_sppsv,
-    LAPACKE_sppsv_work,
-    LAPACKE_sppsvx,
-    LAPACKE_sppsvx_work,
-    LAPACKE_spptrf,
-    LAPACKE_spptrf_work,
-    LAPACKE_spptri,
-    LAPACKE_spptri_work,
-    LAPACKE_spptrs,
-    LAPACKE_spptrs_work,
-    LAPACKE_spstrf,
-    LAPACKE_spstrf_work,
-    LAPACKE_sptcon,
-    LAPACKE_sptcon_work,
-    LAPACKE_spteqr,
-    LAPACKE_spteqr_work,
-    LAPACKE_sptrfs,
-    LAPACKE_sptrfs_work,
-    LAPACKE_sptsv,
-    LAPACKE_sptsv_work,
-    LAPACKE_sptsvx,
-    LAPACKE_sptsvx_work,
-    LAPACKE_spttrf,
-    LAPACKE_spttrf_work,
-    LAPACKE_spttrs,
-    LAPACKE_spttrs_work,
-    LAPACKE_ssbev,
-    LAPACKE_ssbev_work,
-    LAPACKE_ssbevd,
-    LAPACKE_ssbevd_work,
-    LAPACKE_ssbevx,
-    LAPACKE_ssbevx_work,
-    LAPACKE_ssbgst,
-    LAPACKE_ssbgst_work,
-    LAPACKE_ssbgv,
-    LAPACKE_ssbgv_work,
-    LAPACKE_ssbgvd,
-    LAPACKE_ssbgvd_work,
-    LAPACKE_ssbgvx,
-    LAPACKE_ssbgvx_work,
-    LAPACKE_ssbtrd,
-    LAPACKE_ssbtrd_work,
-    LAPACKE_ssfrk,
-    LAPACKE_ssfrk_work,
-    LAPACKE_sspcon,
-    LAPACKE_sspcon_work,
-    LAPACKE_sspev,
-    LAPACKE_sspev_work,
-    LAPACKE_sspevd,
-    LAPACKE_sspevd_work,
-    LAPACKE_sspevx,
-    LAPACKE_sspevx_work,
-    LAPACKE_sspgst,
-    LAPACKE_sspgst_work,
-    LAPACKE_sspgv,
-    LAPACKE_sspgv_work,
-    LAPACKE_sspgvd,
-    LAPACKE_sspgvd_work,
-    LAPACKE_sspgvx,
-    LAPACKE_sspgvx_work,
-    LAPACKE_ssprfs,
-    LAPACKE_ssprfs_work,
-    LAPACKE_sspsv,
-    LAPACKE_sspsv_work,
-    LAPACKE_sspsvx,
-    LAPACKE_sspsvx_work,
-    LAPACKE_ssptrd,
-    LAPACKE_ssptrd_work,
-    LAPACKE_ssptrf,
-    LAPACKE_ssptrf_work,
-    LAPACKE_ssptri,
-    LAPACKE_ssptri_work,
-    LAPACKE_ssptrs,
-    LAPACKE_ssptrs_work,
-    LAPACKE_sstebz,
-    LAPACKE_sstebz_work,
-    LAPACKE_sstedc,
-    LAPACKE_sstedc_work,
-    LAPACKE_sstegr,
-    LAPACKE_sstegr_work,
-    LAPACKE_sstein,
-    LAPACKE_sstein_work,
-    LAPACKE_sstemr,
-    LAPACKE_sstemr_work,
-    LAPACKE_ssteqr,
-    LAPACKE_ssteqr_work,
-    LAPACKE_ssterf,
-    LAPACKE_ssterf_work,
-    LAPACKE_sstev,
-    LAPACKE_sstev_work,
-    LAPACKE_sstevd,
-    LAPACKE_sstevd_work,
-    LAPACKE_sstevr,
-    LAPACKE_sstevr_work,
-    LAPACKE_sstevx,
-    LAPACKE_sstevx_work,
-    LAPACKE_ssycon,
-    LAPACKE_ssycon_work,
-    LAPACKE_ssyconv,
-    LAPACKE_ssyconv_work,
-    LAPACKE_ssyequb,
-    LAPACKE_ssyequb_work,
-    LAPACKE_ssyev,
-    LAPACKE_ssyev_work,
-    LAPACKE_ssyevd,
-    LAPACKE_ssyevd_work,
-    LAPACKE_ssyevr,
-    LAPACKE_ssyevr_work,
-    LAPACKE_ssyevx,
-    LAPACKE_ssyevx_work,
-    LAPACKE_ssygst,
-    LAPACKE_ssygst_work,
-    LAPACKE_ssygv,
-    LAPACKE_ssygv_work,
-    LAPACKE_ssygvd,
-    LAPACKE_ssygvd_work,
-    LAPACKE_ssygvx,
-    LAPACKE_ssygvx_work,
-    LAPACKE_ssyrfs,
-    LAPACKE_ssyrfs_work,
-    LAPACKE_ssysv,
-    LAPACKE_ssysv_rook,
-    LAPACKE_ssysv_rook_work,
-    LAPACKE_ssysv_work,
-    LAPACKE_ssysvx,
-    LAPACKE_ssysvx_work,
-    LAPACKE_ssyswapr,
-    LAPACKE_ssyswapr_work,
-    LAPACKE_ssytrd,
-    LAPACKE_ssytrd_work,
-    LAPACKE_ssytrf,
-    LAPACKE_ssytrf_work,
-    LAPACKE_ssytri,
-    LAPACKE_ssytri2,
-    LAPACKE_ssytri2_work,
-    LAPACKE_ssytri2x,
-    LAPACKE_ssytri2x_work,
-    LAPACKE_ssytri_work,
-    LAPACKE_ssytrs,
-    LAPACKE_ssytrs2,
-    LAPACKE_ssytrs2_work,
-    LAPACKE_ssytrs_work,
-    LAPACKE_stbcon,
-    LAPACKE_stbcon_work,
-    LAPACKE_stbrfs,
-    LAPACKE_stbrfs_work,
-    LAPACKE_stbtrs,
-    LAPACKE_stbtrs_work,
-    LAPACKE_stfsm,
-    LAPACKE_stfsm_work,
-    LAPACKE_stftri,
-    LAPACKE_stftri_work,
-    LAPACKE_stfttp,
-    LAPACKE_stfttp_work,
-    LAPACKE_stfttr,
-    LAPACKE_stfttr_work,
-    LAPACKE_stgevc,
-    LAPACKE_stgevc_work,
-    LAPACKE_stgexc,
-    LAPACKE_stgexc_work,
-    LAPACKE_stgsen,
-    LAPACKE_stgsen_work,
-    LAPACKE_stgsja,
-    LAPACKE_stgsja_work,
-    LAPACKE_stgsna,
-    LAPACKE_stgsna_work,
-    LAPACKE_stgsyl,
-    LAPACKE_stgsyl_work,
-    LAPACKE_stpcon,
-    LAPACKE_stpcon_work,
-    LAPACKE_stpmqrt,
-    LAPACKE_stpmqrt_work,
-    LAPACKE_stpqrt2,
-    LAPACKE_stpqrt2_work,
-    LAPACKE_stprfb,
-    LAPACKE_stprfb_work,
-    LAPACKE_stprfs,
-    LAPACKE_stprfs_work,
-    LAPACKE_stptri,
-    LAPACKE_stptri_work,
-    LAPACKE_stptrs,
-    LAPACKE_stptrs_work,
-    LAPACKE_stpttf,
-    LAPACKE_stpttf_work,
-    LAPACKE_stpttr,
-    LAPACKE_stpttr_work,
-    LAPACKE_strcon,
-    LAPACKE_strcon_work,
-    LAPACKE_strevc,
-    LAPACKE_strevc_work,
-    LAPACKE_strexc,
-    LAPACKE_strexc_work,
-    LAPACKE_strrfs,
-    LAPACKE_strrfs_work,
-    LAPACKE_strsen,
-    LAPACKE_strsen_work,
-    LAPACKE_strsna,
-    LAPACKE_strsna_work,
-    LAPACKE_strsyl,
-    LAPACKE_strsyl_work,
-    LAPACKE_strtri,
-    LAPACKE_strtri_work,
-    LAPACKE_strtrs,
-    LAPACKE_strtrs_work,
-    LAPACKE_strttf,
-    LAPACKE_strttf_work,
-    LAPACKE_strttp,
-    LAPACKE_strttp_work,
-    LAPACKE_stzrzf,
-    LAPACKE_stzrzf_work,
-    LAPACKE_slatms,
-    LAPACKE_slatms_work,
-    LAPACKE_slagge,
-    LAPACKE_slagge_work,
-    LAPACKE_slagsy,
-    LAPACKE_slagsy_work,
-    LAPACKE_sbdsvdx,
-    LAPACKE_sbdsvdx_work,
-    LAPACKE_sgesvdx,
-    LAPACKE_sgesvdx_work,
-    LAPACKE_sgetrf2,
-    LAPACKE_sgetrf2_work,
-    LAPACKE_sgges3,
-    LAPACKE_sgges3_work,
-    LAPACKE_sggev3,
-    LAPACKE_sggev3_work,
-    LAPACKE_sgghd3,
-    LAPACKE_sgghd3_work,
-    LAPACKE_sggsvd3,
-    LAPACKE_sggsvd3_work,
-    LAPACKE_sggsvp3,
-    LAPACKE_sggsvp3_work,
-    LAPACKE_slapmt,
-    LAPACKE_slapmt_work,
-    LAPACKE_slascl,
-    LAPACKE_slascl_work,
-    LAPACKE_sorcsd2by1,
-    LAPACKE_sorcsd2by1_work,
-    LAPACKE_spotrf2,
-    LAPACKE_spotrf2_work,
-    LAPACKE_ssytrf_rook,
-    LAPACKE_ssytrf_rook_work,
-    LAPACKE_ssytrs_rook,
-    LAPACKE_ssytrs_rook_work,
-    LAPACKE_stpqrt,
-    LAPACKE_stpqrt_work,
-    LAPACKE_sgelq,
-    LAPACKE_sgelq_work,
-    LAPACKE_sgemlq,
-    LAPACKE_sgemlq_work,
-    LAPACKE_sgemqr,
-    LAPACKE_sgemqr_work,
-    LAPACKE_sgeqr,
-    LAPACKE_sgeqr_work,
-    LAPACKE_sgetsls,
-    LAPACKE_sgetsls_work,
-    LAPACKE_ssbev_2stage,
-    LAPACKE_ssbev_2stage_work,
-    LAPACKE_ssbevd_2stage,
-    LAPACKE_ssbevd_2stage_work,
-    LAPACKE_ssbevx_2stage,
-    LAPACKE_ssbevx_2stage_work,
-    LAPACKE_ssycon_3,
-    LAPACKE_ssycon_3_work,
-    LAPACKE_ssyev_2stage,
-    LAPACKE_ssyev_2stage_work,
-    LAPACKE_ssyevd_2stage,
-    LAPACKE_ssyevd_2stage_work,
-    LAPACKE_ssyevr_2stage,
-    LAPACKE_ssyevr_2stage_work,
-    LAPACKE_ssyevx_2stage,
-    LAPACKE_ssyevx_2stage_work,
-    LAPACKE_ssygv_2stage,
-    LAPACKE_ssygv_2stage_work,
-    LAPACKE_ssysv_aa,
-    LAPACKE_ssysv_aa_work,
-    LAPACKE_ssysv_rk,
-    LAPACKE_ssysv_rk_work,
-    LAPACKE_ssytrf_aa,
-    LAPACKE_ssytrf_aa_work,
-    LAPACKE_ssytrf_rk,
-    LAPACKE_ssytrf_rk_work,
-    LAPACKE_ssytri_3,
-    LAPACKE_ssytri_3_work,
-    LAPACKE_ssytrs_aa,
-    LAPACKE_ssytrs_aa_work,
-    LAPACKE_ssytrs_3,
-    LAPACKE_ssytrs_3_work,
-    LAPACKE_slassq,
-    LAPACKE_slassq_work,
-    LAPACKE_ssysv_aa_2stage,
-    LAPACKE_ssysv_aa_2stage_work,
-    LAPACKE_ssytrf_aa_2stage,
-    LAPACKE_ssytrf_aa_2stage_work,
-    LAPACKE_ssytrs_aa_2stage,
-    LAPACKE_ssytrs_aa_2stage_work,
-    LAPACKE_sgesvdq,
-    LAPACKE_sgesvdq_work,
-);
-@lapackeobjsz = (    
-    LAPACKE_zgb_nancheck,
-    LAPACKE_zgb_trans,
-    LAPACKE_zge_nancheck,
-    LAPACKE_zge_trans,
-    LAPACKE_zgg_nancheck,
-    LAPACKE_zgg_trans,
-    LAPACKE_zgt_nancheck,
-    LAPACKE_zhb_nancheck,
-    LAPACKE_zhb_trans,
-    LAPACKE_zhe_nancheck,
-    LAPACKE_zhe_trans,
-    LAPACKE_zhp_nancheck,
-    LAPACKE_zhp_trans,
-    LAPACKE_zhs_nancheck,
-    LAPACKE_zhs_trans,
-    LAPACKE_z_nancheck,
-    LAPACKE_zpb_nancheck,
-    LAPACKE_zpb_trans,
-    LAPACKE_zpf_nancheck,
-    LAPACKE_zpf_trans,
-    LAPACKE_zpo_nancheck,
-    LAPACKE_zpo_trans,
-    LAPACKE_zpp_nancheck,
-    LAPACKE_zpp_trans,
-    LAPACKE_zpt_nancheck,
-    LAPACKE_zsp_nancheck,
-    LAPACKE_zsp_trans,
-    LAPACKE_zst_nancheck,
-    LAPACKE_zsy_nancheck,
-    LAPACKE_zsy_trans,
-    LAPACKE_ztb_nancheck,
-    LAPACKE_ztb_trans,
-    LAPACKE_ztf_nancheck,
-    LAPACKE_ztf_trans,
-    LAPACKE_ztp_nancheck,
-    LAPACKE_ztp_trans,
-    LAPACKE_ztr_nancheck,
-    LAPACKE_ztr_trans,
-    LAPACKE_zbbcsd,
-    LAPACKE_zbbcsd_work,
-    LAPACKE_zbdsqr,
-    LAPACKE_zbdsqr_work,
-    LAPACKE_zcgesv,
-    LAPACKE_zcgesv_work,
-    LAPACKE_zcposv,
-    LAPACKE_zcposv_work,
-    LAPACKE_zgbbrd,
-    LAPACKE_zgbbrd_work,
-    LAPACKE_zgbcon,
-    LAPACKE_zgbcon_work,
-    LAPACKE_zgbequ,
-    LAPACKE_zgbequ_work,
-    LAPACKE_zgbequb,
-    LAPACKE_zgbequb_work,
-    LAPACKE_zgbrfs,
-    LAPACKE_zgbrfs_work,
-    LAPACKE_zgbsv,
-    LAPACKE_zgbsv_work,
-    LAPACKE_zgbsvx,
-    LAPACKE_zgbsvx_work,
-    LAPACKE_zgbtrf,
-    LAPACKE_zgbtrf_work,
-    LAPACKE_zgbtrs,
-    LAPACKE_zgbtrs_work,
-    LAPACKE_zgebak,
-    LAPACKE_zgebak_work,
-    LAPACKE_zgebal,
-    LAPACKE_zgebal_work,
-    LAPACKE_zgebrd,
-    LAPACKE_zgebrd_work,
-    LAPACKE_zgecon,
-    LAPACKE_zgecon_work,
-    LAPACKE_zgeequ,
-    LAPACKE_zgeequ_work,
-    LAPACKE_zgeequb,
-    LAPACKE_zgeequb_work,
-    LAPACKE_zgees,
-    LAPACKE_zgees_work,
-    LAPACKE_zgeesx,
-    LAPACKE_zgeesx_work,
-    LAPACKE_zgeev,
-    LAPACKE_zgeev_work,
-    LAPACKE_zgeevx,
-    LAPACKE_zgeevx_work,
-    LAPACKE_zgehrd,
-    LAPACKE_zgehrd_work,
-    LAPACKE_zgelq2,
-    LAPACKE_zgelq2_work,
-    LAPACKE_zgelqf,
-    LAPACKE_zgelqf_work,
-    LAPACKE_zgels,
-    LAPACKE_zgels_work,
-    LAPACKE_zgelsd,
-    LAPACKE_zgelsd_work,
-    LAPACKE_zgelss,
-    LAPACKE_zgelss_work,
-    LAPACKE_zgelsy,
-    LAPACKE_zgelsy_work,
-    LAPACKE_zgemqrt,
-    LAPACKE_zgemqrt_work,
-    LAPACKE_zgeqlf,
-    LAPACKE_zgeqlf_work,
-    LAPACKE_zgeqp3,
-    LAPACKE_zgeqp3_work,
-    LAPACKE_zgeqr2,
-    LAPACKE_zgeqr2_work,
-    LAPACKE_zgeqrf,
-    LAPACKE_zgeqrf_work,
-    LAPACKE_zgeqrfp,
-    LAPACKE_zgeqrfp_work,
-    LAPACKE_zgeqrt,
-    LAPACKE_zgeqrt2,
-    LAPACKE_zgeqrt2_work,
-    LAPACKE_zgeqrt3,
-    LAPACKE_zgeqrt3_work,
-    LAPACKE_zgeqrt_work,
-    LAPACKE_zgerfs,
-    LAPACKE_zgerfs_work,
-    LAPACKE_zgerqf,
-    LAPACKE_zgerqf_work,
-    LAPACKE_zgesdd,
-    LAPACKE_zgesdd_work,
-    LAPACKE_zgesv,
-    LAPACKE_zgesv_work,
-    LAPACKE_zgesvd,
-    LAPACKE_zgesvd_work,
-    LAPACKE_zgesvx,
-    LAPACKE_zgesvx_work,
-    LAPACKE_zgetf2,
-    LAPACKE_zgetf2_work,
-    LAPACKE_zgetrf,
-    LAPACKE_zgetrf_work,
-    LAPACKE_zgetri,
-    LAPACKE_zgetri_work,
-    LAPACKE_zgetrs,
-    LAPACKE_zgetrs_work,
-    LAPACKE_zggbak,
-    LAPACKE_zggbak_work,
-    LAPACKE_zggbal,
-    LAPACKE_zggbal_work,
-    LAPACKE_zgges,
-    LAPACKE_zgges_work,
-    LAPACKE_zggesx,
-    LAPACKE_zggesx_work,
-    LAPACKE_zggev,
-    LAPACKE_zggev_work,
-    LAPACKE_zggevx,
-    LAPACKE_zggevx_work,
-    LAPACKE_zggglm,
-    LAPACKE_zggglm_work,
-    LAPACKE_zgghrd,
-    LAPACKE_zgghrd_work,
-    LAPACKE_zgglse,
-    LAPACKE_zgglse_work,
-    LAPACKE_zggqrf,
-    LAPACKE_zggqrf_work,
-    LAPACKE_zggrqf,
-    LAPACKE_zggrqf_work,
-    LAPACKE_zgtcon,
-    LAPACKE_zgtcon_work,
-    LAPACKE_zgtrfs,
-    LAPACKE_zgtrfs_work,
-    LAPACKE_zgtsv,
-    LAPACKE_zgtsv_work,
-    LAPACKE_zgtsvx,
-    LAPACKE_zgtsvx_work,
-    LAPACKE_zgttrf,
-    LAPACKE_zgttrf_work,
-    LAPACKE_zgttrs,
-    LAPACKE_zgttrs_work,
-    LAPACKE_zhbev,
-    LAPACKE_zhbev_work,
-    LAPACKE_zhbevd,
-    LAPACKE_zhbevd_work,
-    LAPACKE_zhbevx,
-    LAPACKE_zhbevx_work,
-    LAPACKE_zhbgst,
-    LAPACKE_zhbgst_work,
-    LAPACKE_zhbgv,
-    LAPACKE_zhbgv_work,
-    LAPACKE_zhbgvd,
-    LAPACKE_zhbgvd_work,
-    LAPACKE_zhbgvx,
-    LAPACKE_zhbgvx_work,
-    LAPACKE_zhbtrd,
-    LAPACKE_zhbtrd_work,
-    LAPACKE_zhecon,
-    LAPACKE_zhecon_work,
-    LAPACKE_zheequb,
-    LAPACKE_zheequb_work,
-    LAPACKE_zheev,
-    LAPACKE_zheev_work,
-    LAPACKE_zheevd,
-    LAPACKE_zheevd_work,
-    LAPACKE_zheevr,
-    LAPACKE_zheevr_work,
-    LAPACKE_zheevx,
-    LAPACKE_zheevx_work,
-    LAPACKE_zhegst,
-    LAPACKE_zhegst_work,
-    LAPACKE_zhegv,
-    LAPACKE_zhegv_work,
-    LAPACKE_zhegvd,
-    LAPACKE_zhegvd_work,
-    LAPACKE_zhegvx,
-    LAPACKE_zhegvx_work,
-    LAPACKE_zherfs,
-    LAPACKE_zherfs_work,
-    LAPACKE_zhesv,
-    LAPACKE_zhesv_work,
-    LAPACKE_zhesvx,
-    LAPACKE_zhesvx_work,
-    LAPACKE_zheswapr,
-    LAPACKE_zheswapr_work,
-    LAPACKE_zhetrd,
-    LAPACKE_zhetrd_work,
-    LAPACKE_zhetrf,
-    LAPACKE_zhetrf_work,
-    LAPACKE_zhetri,
-    LAPACKE_zhetri2,
-    LAPACKE_zhetri2_work,
-    LAPACKE_zhetri2x,
-    LAPACKE_zhetri2x_work,
-    LAPACKE_zhetri_work,
-    LAPACKE_zhetrs,
-    LAPACKE_zhetrs2,
-    LAPACKE_zhetrs2_work,
-    LAPACKE_zhetrs_work,
-    LAPACKE_zhfrk,
-    LAPACKE_zhfrk_work,
-    LAPACKE_zhgeqz,
-    LAPACKE_zhgeqz_work,
-    LAPACKE_zhpcon,
-    LAPACKE_zhpcon_work,
-    LAPACKE_zhpev,
-    LAPACKE_zhpev_work,
-    LAPACKE_zhpevd,
-    LAPACKE_zhpevd_work,
-    LAPACKE_zhpevx,
-    LAPACKE_zhpevx_work,
-    LAPACKE_zhpgst,
-    LAPACKE_zhpgst_work,
-    LAPACKE_zhpgv,
-    LAPACKE_zhpgv_work,
-    LAPACKE_zhpgvd,
-    LAPACKE_zhpgvd_work,
-    LAPACKE_zhpgvx,
-    LAPACKE_zhpgvx_work,
-    LAPACKE_zhprfs,
-    LAPACKE_zhprfs_work,
-    LAPACKE_zhpsv,
-    LAPACKE_zhpsv_work,
-    LAPACKE_zhpsvx,
-    LAPACKE_zhpsvx_work,
-    LAPACKE_zhptrd,
-    LAPACKE_zhptrd_work,
-    LAPACKE_zhptrf,
-    LAPACKE_zhptrf_work,
-    LAPACKE_zhptri,
-    LAPACKE_zhptri_work,
-    LAPACKE_zhptrs,
-    LAPACKE_zhptrs_work,
-    LAPACKE_zhsein,
-    LAPACKE_zhsein_work,
-    LAPACKE_zhseqr,
-    LAPACKE_zhseqr_work,
-    LAPACKE_zlacgv,
-    LAPACKE_zlacgv_work,
-    LAPACKE_zlacn2,
-    LAPACKE_zlacn2_work,
-    LAPACKE_zlacp2,
-    LAPACKE_zlacp2_work,
-    LAPACKE_zlacpy,
-    LAPACKE_zlacpy_work,
-    LAPACKE_zlag2c,
-    LAPACKE_zlag2c_work,
-    LAPACKE_zlange,
-    LAPACKE_zlange_work,
-    LAPACKE_zlanhe,
-    LAPACKE_zlanhe_work,
-    LAPACKE_zlansy,
-    LAPACKE_zlansy_work,
-    LAPACKE_zlantr,
-    LAPACKE_zlantr_work,
-    LAPACKE_zlapmr,
-    LAPACKE_zlapmr_work,
-    LAPACKE_zlarfb,
-    LAPACKE_zlarfb_work,
-    LAPACKE_zlarfg,
-    LAPACKE_zlarfg_work,
-    LAPACKE_zlarft,
-    LAPACKE_zlarft_work,
-    LAPACKE_zlarfx,
-    LAPACKE_zlarfx_work,
-    LAPACKE_zlarnv,
-    LAPACKE_zlarnv_work,
-    LAPACKE_zlaset,
-    LAPACKE_zlaset_work,
-    LAPACKE_zlaswp,
-    LAPACKE_zlaswp_work,
-    LAPACKE_zlauum,
-    LAPACKE_zlauum_work,
-    LAPACKE_zpbcon,
-    LAPACKE_zpbcon_work,
-    LAPACKE_zpbequ,
-    LAPACKE_zpbequ_work,
-    LAPACKE_zpbrfs,
-    LAPACKE_zpbrfs_work,
-    LAPACKE_zpbstf,
-    LAPACKE_zpbstf_work,
-    LAPACKE_zpbsv,
-    LAPACKE_zpbsv_work,
-    LAPACKE_zpbsvx,
-    LAPACKE_zpbsvx_work,
-    LAPACKE_zpbtrf,
-    LAPACKE_zpbtrf_work,
-    LAPACKE_zpbtrs,
-    LAPACKE_zpbtrs_work,
-    LAPACKE_zpftrf,
-    LAPACKE_zpftrf_work,
-    LAPACKE_zpftri,
-    LAPACKE_zpftri_work,
-    LAPACKE_zpftrs,
-    LAPACKE_zpftrs_work,
-    LAPACKE_zpocon,
-    LAPACKE_zpocon_work,
-    LAPACKE_zpoequ,
-    LAPACKE_zpoequ_work,
-    LAPACKE_zpoequb,
-    LAPACKE_zpoequb_work,
-    LAPACKE_zporfs,
-    LAPACKE_zporfs_work,
-    LAPACKE_zposv,
-    LAPACKE_zposv_work,
-    LAPACKE_zposvx,
-    LAPACKE_zposvx_work,
-    LAPACKE_zpotrf,
-    LAPACKE_zpotrf_work,
-    LAPACKE_zpotri,
-    LAPACKE_zpotri_work,
-    LAPACKE_zpotrs,
-    LAPACKE_zpotrs_work,
-    LAPACKE_zppcon,
-    LAPACKE_zppcon_work,
-    LAPACKE_zppequ,
-    LAPACKE_zppequ_work,
-    LAPACKE_zpprfs,
-    LAPACKE_zpprfs_work,
-    LAPACKE_zppsv,
-    LAPACKE_zppsv_work,
-    LAPACKE_zppsvx,
-    LAPACKE_zppsvx_work,
-    LAPACKE_zpptrf,
-    LAPACKE_zpptrf_work,
-    LAPACKE_zpptri,
-    LAPACKE_zpptri_work,
-    LAPACKE_zpptrs,
-    LAPACKE_zpptrs_work,
-    LAPACKE_zpstrf,
-    LAPACKE_zpstrf_work,
-    LAPACKE_zptcon,
-    LAPACKE_zptcon_work,
-    LAPACKE_zpteqr,
-    LAPACKE_zpteqr_work,
-    LAPACKE_zptrfs,
-    LAPACKE_zptrfs_work,
-    LAPACKE_zptsv,
-    LAPACKE_zptsv_work,
-    LAPACKE_zptsvx,
-    LAPACKE_zptsvx_work,
-    LAPACKE_zpttrf,
-    LAPACKE_zpttrf_work,
-    LAPACKE_zpttrs,
-    LAPACKE_zpttrs_work,
-    LAPACKE_zspcon,
-    LAPACKE_zspcon_work,
-    LAPACKE_zsprfs,
-    LAPACKE_zsprfs_work,
-    LAPACKE_zspsv,
-    LAPACKE_zspsv_work,
-    LAPACKE_zspsvx,
-    LAPACKE_zspsvx_work,
-    LAPACKE_zsptrf,
-    LAPACKE_zsptrf_work,
-    LAPACKE_zsptri,
-    LAPACKE_zsptri_work,
-    LAPACKE_zsptrs,
-    LAPACKE_zsptrs_work,
-    LAPACKE_zstedc,
-    LAPACKE_zstedc_work,
-    LAPACKE_zstegr,
-    LAPACKE_zstegr_work,
-    LAPACKE_zstein,
-    LAPACKE_zstein_work,
-    LAPACKE_zstemr,
-    LAPACKE_zstemr_work,
-    LAPACKE_zsteqr,
-    LAPACKE_zsteqr_work,
-    LAPACKE_zsycon,
-    LAPACKE_zsycon_work,
-    LAPACKE_zsyconv,
-    LAPACKE_zsyconv_work,
-    LAPACKE_zsyequb,
-    LAPACKE_zsyequb_work,
-    LAPACKE_zsyrfs,
-    LAPACKE_zsyrfs_work,
-    LAPACKE_zsysv,
-    LAPACKE_zsysv_rook,
-    LAPACKE_zsysv_rook_work,
-    LAPACKE_zsysv_work,
-    LAPACKE_zsysvx,
-    LAPACKE_zsysvx_work,
-    LAPACKE_zsyswapr,
-    LAPACKE_zsyswapr_work,
-    LAPACKE_zsytrf,
-    LAPACKE_zsytrf_work,
-    LAPACKE_zsytri,
-    LAPACKE_zsytri2,
-    LAPACKE_zsytri2_work,
-    LAPACKE_zsytri2x,
-    LAPACKE_zsytri2x_work,
-    LAPACKE_zsytri_work,
-    LAPACKE_zsytrs,
-    LAPACKE_zsytrs2,
-    LAPACKE_zsytrs2_work,
-    LAPACKE_zsytrs_work,
-    LAPACKE_ztbcon,
-    LAPACKE_ztbcon_work,
-    LAPACKE_ztbrfs,
-    LAPACKE_ztbrfs_work,
-    LAPACKE_ztbtrs,
-    LAPACKE_ztbtrs_work,
-    LAPACKE_ztfsm,
-    LAPACKE_ztfsm_work,
-    LAPACKE_ztftri,
-    LAPACKE_ztftri_work,
-    LAPACKE_ztfttp,
-    LAPACKE_ztfttp_work,
-    LAPACKE_ztfttr,
-    LAPACKE_ztfttr_work,
-    LAPACKE_ztgevc,
-    LAPACKE_ztgevc_work,
-    LAPACKE_ztgexc,
-    LAPACKE_ztgexc_work,
-    LAPACKE_ztgsen,
-    LAPACKE_ztgsen_work,
-    LAPACKE_ztgsja,
-    LAPACKE_ztgsja_work,
-    LAPACKE_ztgsna,
-    LAPACKE_ztgsna_work,
-    LAPACKE_ztgsyl,
-    LAPACKE_ztgsyl_work,
-    LAPACKE_ztpcon,
-    LAPACKE_ztpcon_work,
-    LAPACKE_ztpmqrt,
-    LAPACKE_ztpmqrt_work,
-    LAPACKE_ztpqrt,
-    LAPACKE_ztpqrt2,
-    LAPACKE_ztpqrt2_work,
-    LAPACKE_ztpqrt_work,
-    LAPACKE_ztprfb,
-    LAPACKE_ztprfb_work,
-    LAPACKE_ztprfs,
-    LAPACKE_ztprfs_work,
-    LAPACKE_ztptri,
-    LAPACKE_ztptri_work,
-    LAPACKE_ztptrs,
-    LAPACKE_ztptrs_work,
-    LAPACKE_ztpttf,
-    LAPACKE_ztpttf_work,
-    LAPACKE_ztpttr,
-    LAPACKE_ztpttr_work,
-    LAPACKE_ztrcon,
-    LAPACKE_ztrcon_work,
-    LAPACKE_ztrevc,
-    LAPACKE_ztrevc_work,
-    LAPACKE_ztrexc,
-    LAPACKE_ztrexc_work,
-    LAPACKE_ztrrfs,
-    LAPACKE_ztrrfs_work,
-    LAPACKE_ztrsen,
-    LAPACKE_ztrsen_work,
-    LAPACKE_ztrsna,
-    LAPACKE_ztrsna_work,
-    LAPACKE_ztrsyl,
-    LAPACKE_ztrsyl_work,
-    LAPACKE_ztrtri,
-    LAPACKE_ztrtri_work,
-    LAPACKE_ztrtrs,
-    LAPACKE_ztrtrs_work,
-    LAPACKE_ztrttf,
-    LAPACKE_ztrttf_work,
-    LAPACKE_ztrttp,
-    LAPACKE_ztrttp_work,
-    LAPACKE_ztzrzf,
-    LAPACKE_ztzrzf_work,
-    LAPACKE_zunbdb,
-    LAPACKE_zunbdb_work,
-    LAPACKE_zuncsd,
-    LAPACKE_zuncsd_work,
-    LAPACKE_zungbr,
-    LAPACKE_zungbr_work,
-    LAPACKE_zunghr,
-    LAPACKE_zunghr_work,
-    LAPACKE_zunglq,
-    LAPACKE_zunglq_work,
-    LAPACKE_zungql,
-    LAPACKE_zungql_work,
-    LAPACKE_zungqr,
-    LAPACKE_zungqr_work,
-    LAPACKE_zungrq,
-    LAPACKE_zungrq_work,
-    LAPACKE_zungtr,
-    LAPACKE_zungtr_work,
-    LAPACKE_zunmbr,
-    LAPACKE_zunmbr_work,
-    LAPACKE_zunmhr,
-    LAPACKE_zunmhr_work,
-    LAPACKE_zunmlq,
-    LAPACKE_zunmlq_work,
-    LAPACKE_zunmql,
-    LAPACKE_zunmql_work,
-    LAPACKE_zunmqr,
-    LAPACKE_zunmqr_work,
-    LAPACKE_zunmrq,
-    LAPACKE_zunmrq_work,
-    LAPACKE_zunmrz,
-    LAPACKE_zunmrz_work,
-    LAPACKE_zunmtr,
-    LAPACKE_zunmtr_work,
-    LAPACKE_zupgtr,
-    LAPACKE_zupgtr_work,
-    LAPACKE_zupmtr,
-    LAPACKE_zupmtr_work,
-    LAPACKE_zsyr,
-    LAPACKE_zsyr_work,
-    ## @(SRCX_OBJ) from `lapack-3.4.1/lapacke/src/Makefile`
-    ## Not exported: requires LAPACKE_EXTENDED to be set and depends on the
-    ##               corresponding LAPACK extended precision routines.
-    #LAPACKE_cgbrfsx,
-    #LAPACKE_cporfsx,
-    #LAPACKE_dgerfsx,
-    #LAPACKE_sgbrfsx,
-    #LAPACKE_ssyrfsx,
-    #LAPACKE_zherfsx,
-    #LAPACKE_cgbrfsx_work,
-    #LAPACKE_cporfsx_work,
-    #LAPACKE_dgerfsx_work,
-    #LAPACKE_sgbrfsx_work,
-    #LAPACKE_ssyrfsx_work,
-    #LAPACKE_zherfsx_work,
-    #LAPACKE_cgerfsx,
-    #LAPACKE_csyrfsx,
-    #LAPACKE_dporfsx,
-    #LAPACKE_sgerfsx,
-    #LAPACKE_zgbrfsx,
-    #LAPACKE_zporfsx,
-    #LAPACKE_cgerfsx_work,
-    #LAPACKE_csyrfsx_work,
-    #LAPACKE_dporfsx_work,
-    #LAPACKE_sgerfsx_work,
-    #LAPACKE_zgbrfsx_work,
-    #LAPACKE_zporfsx_work,
-    #LAPACKE_cherfsx,
-    #LAPACKE_dgbrfsx,
-    #LAPACKE_dsyrfsx,
-    #LAPACKE_sporfsx,
-    #LAPACKE_zgerfsx,
-    #LAPACKE_zsyrfsx,
-    #LAPACKE_cherfsx_work,
-    #LAPACKE_dgbrfsx_work,
-    #LAPACKE_dsyrfsx_work,
-    #LAPACKE_sporfsx_work,
-    #LAPACKE_zgerfsx_work,
-    #LAPACKE_zsyrfsx_work,
-    #LAPACKE_cgbsvxx,
-    #LAPACKE_cposvxx,
-    #LAPACKE_dgesvxx,
-    #LAPACKE_sgbsvxx,
-    #LAPACKE_ssysvxx,
-    #LAPACKE_zhesvxx,
-    #LAPACKE_cgbsvxx_work,
-    #LAPACKE_cposvxx_work,
-    #LAPACKE_dgesvxx_work,
-    #LAPACKE_sgbsvxx_work,
-    #LAPACKE_ssysvxx_work,
-    #LAPACKE_zhesvxx_work,
-    #LAPACKE_cgesvxx,
-    #LAPACKE_csysvxx,
-    #LAPACKE_dposvxx,
-    #LAPACKE_sgesvxx,
-    #LAPACKE_zgbsvxx,
-    #LAPACKE_zposvxx,
-    #LAPACKE_cgesvxx_work,
-    #LAPACKE_csysvxx_work,
-    #LAPACKE_dposvxx_work,
-    #LAPACKE_sgesvxx_work,
-    #LAPACKE_zgbsvxx_work,
-    #LAPACKE_zposvxx_work,
-    #LAPACKE_chesvxx,
-    #LAPACKE_dgbsvxx,
-    #LAPACKE_dsysvxx,
-    #LAPACKE_sposvxx,
-    #LAPACKE_zgesvxx,
-    #LAPACKE_zsysvxx,
-    #LAPACKE_chesvxx_work,
-    #LAPACKE_dgbsvxx_work,
-    #LAPACKE_dsysvxx_work,
-    #LAPACKE_sposvxx_work,
-    #LAPACKE_zgesvxx_work,
-    #LAPACKE_zsysvxx_work,
+lapacke_deprecated_objsz="
+    LAPACKE_zggsvp
+    LAPACKE_zggsvp_work
+    LAPACKE_zggsvd
+    LAPACKE_zggsvd_work
+    LAPACKE_zgeqpf
+    LAPACKE_zgeqpf_work
+"
 
-    ## @(MATGEN_OBJ) from `lapack-3.4.1/lapacke/src/Makefile`
-    ## Not exported: requires LAPACKE_TESTING to be set and depends on libtmg
-    ##               (see `lapack-3.4.1/TESTING/MATGEN`).
-    LAPACKE_zlatms,
-    LAPACKE_zlatms_work,
-    LAPACKE_zlagge,
-    LAPACKE_zlagge_work,
-    LAPACKE_zlaghe,
-    LAPACKE_zlaghe_work,
-    LAPACKE_zlagsy,
-    LAPACKE_zlagsy_work,
-    ## new function from lapack-3.6.0
-    LAPACKE_zgejsv,
-    LAPACKE_zgejsv_work,
-    LAPACKE_zgesvdx,
-    LAPACKE_zgesvdx_work,
-    LAPACKE_zgesvj,
-    LAPACKE_zgesvj_work,
-    LAPACKE_zgetrf2,
-    LAPACKE_zgetrf2_work,
-    LAPACKE_zgges3,
-    LAPACKE_zgges3_work,
-    LAPACKE_zggev3,
-    LAPACKE_zggev3_work,
-    LAPACKE_zgghd3,
-    LAPACKE_zgghd3_work,
-    LAPACKE_zggsvd3,
-    LAPACKE_zggsvd3_work,
-    LAPACKE_zggsvp3,
-    LAPACKE_zggsvp3_work,
-    LAPACKE_zhetrf_rook,
-    LAPACKE_zhetrf_rook_work,
-    LAPACKE_zhetrs_rook,
-    LAPACKE_zhetrs_rook_work,
-    LAPACKE_zlapmt,
-    LAPACKE_zlapmt_work,
-    LAPACKE_zlascl,
-    LAPACKE_zlascl_work,
-    LAPACKE_zpotrf2,
-    LAPACKE_zpotrf2_work,
-    LAPACKE_zsytrf_rook,
-    LAPACKE_zsytrf_rook_work,
-    LAPACKE_zsytrs_rook,
-    LAPACKE_zsytrs_rook_work,
-    LAPACKE_zuncsd2by1,
-    LAPACKE_zuncsd2by1_work,
+# LAPACK C interface routines.
+#
+# This list is prepared in a similar manner to @lapackobjs2, however the
+# functions all begin with an uppercase prefix (with the exception of the
+# make_complex_* routines).
+#
+# The functions corresponding to @(MATGEN_OBJ) and @(SRCX_OBJ) are not
+# exported since the respective LAPACK routines are not built by default.
 
-    ## new function from lapack-3.7.0
-    LAPACKE_zgelq,
-    LAPACKE_zgelq_work,
-    LAPACKE_zgemlq,
-    LAPACKE_zgemlq_work,
-    LAPACKE_zgemqr,
-    LAPACKE_zgemqr_work,
-    LAPACKE_zgeqr,
-    LAPACKE_zgeqr_work,
-    LAPACKE_zgetsls,
-    LAPACKE_zgetsls_work,
-    LAPACKE_zhbev_2stage,
-    LAPACKE_zhbev_2stage_work,
-    LAPACKE_zhbevd_2stage,
-    LAPACKE_zhbevd_2stage_work,
-    LAPACKE_zhbevx_2stage,
-    LAPACKE_zhbevx_2stage_work,
-    LAPACKE_zhecon_3,
-    LAPACKE_zhecon_3_work,
-    LAPACKE_zheev_2stage,
-    LAPACKE_zheev_2stage_work,
-    LAPACKE_zheevd_2stage,
-    LAPACKE_zheevd_2stage_work,
-    LAPACKE_zheevr_2stage,
-    LAPACKE_zheevr_2stage_work,
-    LAPACKE_zheevx_2stage,
-    LAPACKE_zheevx_2stage_work,
-    LAPACKE_zhegv_2stage,
-    LAPACKE_zhegv_2stage_work,
-    LAPACKE_zhesv_aa,
-    LAPACKE_zhesv_aa_work,
-    LAPACKE_zhesv_rk,
-    LAPACKE_zhesv_rk_work,
-    LAPACKE_zhetrf_aa,
-    LAPACKE_zhetrf_aa_work,
-    LAPACKE_zhetrf_rk,
-    LAPACKE_zhetrf_rk_work,
-    LAPACKE_zhetri_3,
-    LAPACKE_zhetri_3_work,
-    LAPACKE_zhetrs_aa,
-    LAPACKE_zhetrs_aa_work,
-    LAPACKE_zhetrs_3,
-    LAPACKE_zhetrs_3_work,
-    LAPACKE_zsycon_3,
-    LAPACKE_zsycon_3_work,
-    LAPACKE_zsysv_aa,
-    LAPACKE_zsysv_aa_work,
-    LAPACKE_zsysv_rk,
-    LAPACKE_zsysv_rk_work,
-    LAPACKE_zsytrf_aa,
-    LAPACKE_zsytrf_aa_work,
-    LAPACKE_zsytrf_rk,
-    LAPACKE_zsytrf_rk_work,
-    LAPACKE_zsytri_3,
-    LAPACKE_zsytri_3_work,
-    LAPACKE_zsytrs_aa,
-    LAPACKE_zsytrs_aa_work,
-    LAPACKE_zsytrs_3,
-    LAPACKE_zsytrs_3_work,
-    
-    ## new function from lapack-3.8.0
-    LAPACKE_zhesv_aa_2stage,
-    LAPACKE_zhesv_aa_2stage_work,
-    LAPACKE_zhetrf_aa_2stage,
-    LAPACKE_zhetrf_aa_2stage_work,
-    LAPACKE_zhetrs_aa_2stage,
-    LAPACKE_zhetrs_aa_2stage_work,
-    LAPACKE_zlacrm,
-    LAPACKE_zlacrm_work,
-    LAPACKE_zlarcm,
-    LAPACKE_zlarcm_work,
-    LAPACKE_zlassq,
-    LAPACKE_zlassq_work,
-    LAPACKE_zsysv_aa_2stage,
-    LAPACKE_zsysv_aa_2stage_work,
-    LAPACKE_zsytrf_aa_2stage,
-    LAPACKE_zsytrf_aa_2stage_work,
-    LAPACKE_zsytrs_aa_2stage,
-    LAPACKE_zsytrs_aa_2stage_work,
-    # new functions from 3.9.0
-    LAPACKE_zgesvdq,
+# @(OBJ) from `lapack-3.4.1/lapacke/utils/Makefile`
+lapackeobjs="
+    LAPACKE_lsame
+    LAPACKE_ilaver
+    LAPACKE_xerbla
+    lapack_make_complex_float
+    lapack_make_complex_double
+    LAPACKE_get_nancheck
+    LAPACKE_set_nancheck
+"
+
+lapackeobjsc="
+    LAPACKE_cgb_nancheck
+    LAPACKE_cgb_trans
+    LAPACKE_cge_nancheck
+    LAPACKE_cge_trans
+    LAPACKE_cgg_nancheck
+    LAPACKE_cgg_trans
+    LAPACKE_cgt_nancheck
+    LAPACKE_chb_nancheck
+    LAPACKE_chb_trans
+    LAPACKE_che_nancheck
+    LAPACKE_che_trans
+    LAPACKE_chp_nancheck
+    LAPACKE_chp_trans
+    LAPACKE_chs_nancheck
+    LAPACKE_chs_trans
+    LAPACKE_c_nancheck
+    LAPACKE_cpb_nancheck
+    LAPACKE_cpb_trans
+    LAPACKE_cpf_nancheck
+    LAPACKE_cpf_trans
+    LAPACKE_cpo_nancheck
+    LAPACKE_cpo_trans
+    LAPACKE_cpp_nancheck
+    LAPACKE_cpp_trans
+    LAPACKE_cpt_nancheck
+    LAPACKE_csp_nancheck
+    LAPACKE_csp_trans
+    LAPACKE_cst_nancheck
+    LAPACKE_csy_nancheck
+    LAPACKE_csy_trans
+    LAPACKE_ctb_nancheck
+    LAPACKE_ctb_trans
+    LAPACKE_ctf_nancheck
+    LAPACKE_ctf_trans
+    LAPACKE_ctp_nancheck
+    LAPACKE_ctp_trans
+    LAPACKE_ctr_nancheck
+    LAPACKE_ctr_trans
+    LAPACKE_cbbcsd
+    LAPACKE_cbbcsd_work
+    LAPACKE_cbdsqr
+    LAPACKE_cbdsqr_work
+    LAPACKE_cgbbrd
+    LAPACKE_cgbbrd_work
+    LAPACKE_cgbcon
+    LAPACKE_cgbcon_work
+    LAPACKE_cgbequ
+    LAPACKE_cgbequ_work
+    LAPACKE_cgbequb
+    LAPACKE_cgbequb_work
+    LAPACKE_cgbrfs
+    LAPACKE_cgbrfs_work
+    LAPACKE_cgbsv
+    LAPACKE_cgbsv_work
+    LAPACKE_cgbsvx
+    LAPACKE_cgbsvx_work
+    LAPACKE_cgbtrf
+    LAPACKE_cgbtrf_work
+    LAPACKE_cgbtrs
+    LAPACKE_cgbtrs_work
+    LAPACKE_cgebak
+    LAPACKE_cgebak_work
+    LAPACKE_cgebal
+    LAPACKE_cgebal_work
+    LAPACKE_cgebrd
+    LAPACKE_cgebrd_work
+    LAPACKE_cgecon
+    LAPACKE_cgecon_work
+    LAPACKE_cgedmd
+    LAPACKE_cgedmd_work
+    LAPACKE_cgedmdq
+    LAPACKE_cgedmdq_work
+    LAPACKE_cgeequ
+    LAPACKE_cgeequ_work
+    LAPACKE_cgeequb
+    LAPACKE_cgeequb_work
+    LAPACKE_cgees
+    LAPACKE_cgees_work
+    LAPACKE_cgeesx
+    LAPACKE_cgeesx_work
+    LAPACKE_cgeev
+    LAPACKE_cgeev_work
+    LAPACKE_cgeevx
+    LAPACKE_cgeevx_work
+    LAPACKE_cgehrd
+    LAPACKE_cgehrd_work
+    LAPACKE_cgelq2
+    LAPACKE_cgelq2_work
+    LAPACKE_cgelqf
+    LAPACKE_cgelqf_work
+    LAPACKE_cgels
+    LAPACKE_cgels_work
+    LAPACKE_cgelsd
+    LAPACKE_cgelsd_work
+    LAPACKE_cgelss
+    LAPACKE_cgelss_work
+    LAPACKE_cgelsy
+    LAPACKE_cgelsy_work
+    LAPACKE_cgemqrt
+    LAPACKE_cgemqrt_work
+    LAPACKE_cgeqlf
+    LAPACKE_cgeqlf_work
+    LAPACKE_cgeqp3
+    LAPACKE_cgeqp3_work
+    LAPACKE_cgeqr2
+    LAPACKE_cgeqr2_work
+    LAPACKE_cgeqrf
+    LAPACKE_cgeqrf_work
+    LAPACKE_cgeqrfp
+    LAPACKE_cgeqrfp_work
+    LAPACKE_cgeqrt
+    LAPACKE_cgeqrt2
+    LAPACKE_cgeqrt2_work
+    LAPACKE_cgeqrt3
+    LAPACKE_cgeqrt3_work
+    LAPACKE_cgeqrt_work
+    LAPACKE_cgerfs
+    LAPACKE_cgerfs_work
+    LAPACKE_cgerqf
+    LAPACKE_cgerqf_work
+    LAPACKE_cgesdd
+    LAPACKE_cgesdd_work
+    LAPACKE_cgesv
+    LAPACKE_cgesv_work
+    LAPACKE_cgesvd
+    LAPACKE_cgesvd_work
+    LAPACKE_cgesvx
+    LAPACKE_cgesvx_work
+    LAPACKE_cgetf2
+    LAPACKE_cgetf2_work
+    LAPACKE_cgetrf
+    LAPACKE_cgetrf_work
+    LAPACKE_cgetri
+    LAPACKE_cgetri_work
+    LAPACKE_cgetrs
+    LAPACKE_cgetrs_work
+    LAPACKE_cggbak
+    LAPACKE_cggbak_work
+    LAPACKE_cggbal
+    LAPACKE_cggbal_work
+    LAPACKE_cgges
+    LAPACKE_cgges_work
+    LAPACKE_cggesx
+    LAPACKE_cggesx_work
+    LAPACKE_cggev
+    LAPACKE_cggev_work
+    LAPACKE_cggevx
+    LAPACKE_cggevx_work
+    LAPACKE_cggglm
+    LAPACKE_cggglm_work
+    LAPACKE_cgghrd
+    LAPACKE_cgghrd_work
+    LAPACKE_cgglse
+    LAPACKE_cgglse_work
+    LAPACKE_cggqrf
+    LAPACKE_cggqrf_work
+    LAPACKE_cggrqf
+    LAPACKE_cggrqf_work
+    LAPACKE_cgtcon
+    LAPACKE_cgtcon_work
+    LAPACKE_cgtrfs
+    LAPACKE_cgtrfs_work
+    LAPACKE_cgtsv
+    LAPACKE_cgtsv_work
+    LAPACKE_cgtsvx
+    LAPACKE_cgtsvx_work
+    LAPACKE_cgttrf
+    LAPACKE_cgttrf_work
+    LAPACKE_cgttrs
+    LAPACKE_cgttrs_work
+    LAPACKE_chbev
+    LAPACKE_chbev_work
+    LAPACKE_chbevd
+    LAPACKE_chbevd_work
+    LAPACKE_chbevx
+    LAPACKE_chbevx_work
+    LAPACKE_chbgst
+    LAPACKE_chbgst_work
+    LAPACKE_chbgv
+    LAPACKE_chbgv_work
+    LAPACKE_chbgvd
+    LAPACKE_chbgvd_work
+    LAPACKE_chbgvx
+    LAPACKE_chbgvx_work
+    LAPACKE_chbtrd
+    LAPACKE_chbtrd_work
+    LAPACKE_checon
+    LAPACKE_checon_work
+    LAPACKE_cheequb
+    LAPACKE_cheequb_work
+    LAPACKE_cheev
+    LAPACKE_cheev_work
+    LAPACKE_cheevd
+    LAPACKE_cheevd_work
+    LAPACKE_cheevr
+    LAPACKE_cheevr_work
+    LAPACKE_cheevx
+    LAPACKE_cheevx_work
+    LAPACKE_chegst
+    LAPACKE_chegst_work
+    LAPACKE_chegv
+    LAPACKE_chegv_work
+    LAPACKE_chegvd
+    LAPACKE_chegvd_work
+    LAPACKE_chegvx
+    LAPACKE_chegvx_work
+    LAPACKE_cherfs
+    LAPACKE_cherfs_work
+    LAPACKE_chesv
+    LAPACKE_chesv_work
+    LAPACKE_chesvx
+    LAPACKE_chesvx_work
+    LAPACKE_cheswapr
+    LAPACKE_cheswapr_work
+    LAPACKE_chetrd
+    LAPACKE_chetrd_work
+    LAPACKE_chetrf
+    LAPACKE_chetrf_work
+    LAPACKE_chetri
+    LAPACKE_chetri2
+    LAPACKE_chetri2_work
+    LAPACKE_chetri2x
+    LAPACKE_chetri2x_work
+    LAPACKE_chetri_work
+    LAPACKE_chetrs
+    LAPACKE_chetrs2
+    LAPACKE_chetrs2_work
+    LAPACKE_chetrs_work
+    LAPACKE_chfrk
+    LAPACKE_chfrk_work
+    LAPACKE_chgeqz
+    LAPACKE_chgeqz_work
+    LAPACKE_chpcon
+    LAPACKE_chpcon_work
+    LAPACKE_chpev
+    LAPACKE_chpev_work
+    LAPACKE_chpevd
+    LAPACKE_chpevd_work
+    LAPACKE_chpevx
+    LAPACKE_chpevx_work
+    LAPACKE_chpgst
+    LAPACKE_chpgst_work
+    LAPACKE_chpgv
+    LAPACKE_chpgv_work
+    LAPACKE_chpgvd
+    LAPACKE_chpgvd_work
+    LAPACKE_chpgvx
+    LAPACKE_chpgvx_work
+    LAPACKE_chprfs
+    LAPACKE_chprfs_work
+    LAPACKE_chpsv
+    LAPACKE_chpsv_work
+    LAPACKE_chpsvx
+    LAPACKE_chpsvx_work
+    LAPACKE_chptrd
+    LAPACKE_chptrd_work
+    LAPACKE_chptrf
+    LAPACKE_chptrf_work
+    LAPACKE_chptri
+    LAPACKE_chptri_work
+    LAPACKE_chptrs
+    LAPACKE_chptrs_work
+    LAPACKE_chsein
+    LAPACKE_chsein_work
+    LAPACKE_chseqr
+    LAPACKE_chseqr_work
+    LAPACKE_clacgv
+    LAPACKE_clacgv_work
+    LAPACKE_clacn2
+    LAPACKE_clacn2_work
+    LAPACKE_clacp2
+    LAPACKE_clacp2_work
+    LAPACKE_clacpy
+    LAPACKE_clacpy_work
+    LAPACKE_clag2z
+    LAPACKE_clag2z_work
+    LAPACKE_clange
+    LAPACKE_clange_work
+    LAPACKE_clanhe
+    LAPACKE_clanhe_work
+    LAPACKE_clansy
+    LAPACKE_clansy_work
+    LAPACKE_clantr
+    LAPACKE_clantr_work
+    LAPACKE_clapmr
+    LAPACKE_clapmr_work
+    LAPACKE_clarfb
+    LAPACKE_clarfb_work
+    LAPACKE_clarfg
+    LAPACKE_clarfg_work
+    LAPACKE_clarft
+    LAPACKE_clarft_work
+    LAPACKE_clarfx
+    LAPACKE_clarfx_work
+    LAPACKE_clarnv
+    LAPACKE_clarnv_work
+    LAPACKE_claset
+    LAPACKE_claset_work
+    LAPACKE_claswp
+    LAPACKE_claswp_work
+    LAPACKE_clauum
+    LAPACKE_clauum_work
+    LAPACKE_cpbcon
+    LAPACKE_cpbcon_work
+    LAPACKE_cpbequ
+    LAPACKE_cpbequ_work
+    LAPACKE_cpbrfs
+    LAPACKE_cpbrfs_work
+    LAPACKE_cpbstf
+    LAPACKE_cpbstf_work
+    LAPACKE_cpbsv
+    LAPACKE_cpbsv_work
+    LAPACKE_cpbsvx
+    LAPACKE_cpbsvx_work
+    LAPACKE_cpbtrf
+    LAPACKE_cpbtrf_work
+    LAPACKE_cpbtrs
+    LAPACKE_cpbtrs_work
+    LAPACKE_cpftrf
+    LAPACKE_cpftrf_work
+    LAPACKE_cpftri
+    LAPACKE_cpftri_work
+    LAPACKE_cpftrs
+    LAPACKE_cpftrs_work
+    LAPACKE_cpocon
+    LAPACKE_cpocon_work
+    LAPACKE_cpoequ
+    LAPACKE_cpoequ_work
+    LAPACKE_cpoequb
+    LAPACKE_cpoequb_work
+    LAPACKE_cporfs
+    LAPACKE_cporfs_work
+    LAPACKE_cposv
+    LAPACKE_cposv_work
+    LAPACKE_cposvx
+    LAPACKE_cposvx_work
+    LAPACKE_cpotrf
+    LAPACKE_cpotrf_work
+    LAPACKE_cpotri
+    LAPACKE_cpotri_work
+    LAPACKE_cpotrs
+    LAPACKE_cpotrs_work
+    LAPACKE_cppcon
+    LAPACKE_cppcon_work
+    LAPACKE_cppequ
+    LAPACKE_cppequ_work
+    LAPACKE_cpprfs
+    LAPACKE_cpprfs_work
+    LAPACKE_cppsv
+    LAPACKE_cppsv_work
+    LAPACKE_cppsvx
+    LAPACKE_cppsvx_work
+    LAPACKE_cpptrf
+    LAPACKE_cpptrf_work
+    LAPACKE_cpptri
+    LAPACKE_cpptri_work
+    LAPACKE_cpptrs
+    LAPACKE_cpptrs_work
+    LAPACKE_cpstrf
+    LAPACKE_cpstrf_work
+    LAPACKE_cptcon
+    LAPACKE_cptcon_work
+    LAPACKE_cpteqr
+    LAPACKE_cpteqr_work
+    LAPACKE_cptrfs
+    LAPACKE_cptrfs_work
+    LAPACKE_cptsv
+    LAPACKE_cptsv_work
+    LAPACKE_cptsvx
+    LAPACKE_cptsvx_work
+    LAPACKE_cpttrf
+    LAPACKE_cpttrf_work
+    LAPACKE_cpttrs
+    LAPACKE_cpttrs_work
+    LAPACKE_cspcon
+    LAPACKE_cspcon_work
+    LAPACKE_csprfs
+    LAPACKE_csprfs_work
+    LAPACKE_cspsv
+    LAPACKE_cspsv_work
+    LAPACKE_cspsvx
+    LAPACKE_cspsvx_work
+    LAPACKE_csptrf
+    LAPACKE_csptrf_work
+    LAPACKE_csptri
+    LAPACKE_csptri_work
+    LAPACKE_csptrs
+    LAPACKE_csptrs_work
+    LAPACKE_cstedc
+    LAPACKE_cstedc_work
+    LAPACKE_cstegr
+    LAPACKE_cstegr_work
+    LAPACKE_cstein
+    LAPACKE_cstein_work
+    LAPACKE_cstemr
+    LAPACKE_cstemr_work
+    LAPACKE_csteqr
+    LAPACKE_csteqr_work
+    LAPACKE_csycon
+    LAPACKE_csycon_work
+    LAPACKE_csyconv
+    LAPACKE_csyconv_work
+    LAPACKE_csyequb
+    LAPACKE_csyequb_work
+    LAPACKE_csyrfs
+    LAPACKE_csyrfs_work
+    LAPACKE_csysv
+    LAPACKE_csysv_rook
+    LAPACKE_csysv_rook_work
+    LAPACKE_csysv_work
+    LAPACKE_csysvx
+    LAPACKE_csysvx_work
+    LAPACKE_csyswapr
+    LAPACKE_csyswapr_work
+    LAPACKE_csytrf
+    LAPACKE_csytrf_work
+    LAPACKE_csytri
+    LAPACKE_csytri2
+    LAPACKE_csytri2_work
+    LAPACKE_csytri2x
+    LAPACKE_csytri2x_work
+    LAPACKE_csytri_work
+    LAPACKE_csytrs
+    LAPACKE_csytrs2
+    LAPACKE_csytrs2_work
+    LAPACKE_csytrs_work
+    LAPACKE_ctbcon
+    LAPACKE_ctbcon_work
+    LAPACKE_ctbrfs
+    LAPACKE_ctbrfs_work
+    LAPACKE_ctbtrs
+    LAPACKE_ctbtrs_work
+    LAPACKE_ctfsm
+    LAPACKE_ctfsm_work
+    LAPACKE_ctftri
+    LAPACKE_ctftri_work
+    LAPACKE_ctfttp
+    LAPACKE_ctfttp_work
+    LAPACKE_ctfttr
+    LAPACKE_ctfttr_work
+    LAPACKE_ctgevc
+    LAPACKE_ctgevc_work
+    LAPACKE_ctgexc
+    LAPACKE_ctgexc_work
+    LAPACKE_ctgsen
+    LAPACKE_ctgsen_work
+    LAPACKE_ctgsja
+    LAPACKE_ctgsja_work
+    LAPACKE_ctgsna
+    LAPACKE_ctgsna_work
+    LAPACKE_ctgsyl
+    LAPACKE_ctgsyl_work
+    LAPACKE_ctpcon
+    LAPACKE_ctpcon_work
+    LAPACKE_ctpmqrt
+    LAPACKE_ctpmqrt_work
+    LAPACKE_ctpqrt
+    LAPACKE_ctpqrt2
+    LAPACKE_ctpqrt2_work
+    LAPACKE_ctpqrt_work
+    LAPACKE_ctprfb
+    LAPACKE_ctprfb_work
+    LAPACKE_ctprfs
+    LAPACKE_ctprfs_work
+    LAPACKE_ctptri
+    LAPACKE_ctptri_work
+    LAPACKE_ctptrs
+    LAPACKE_ctptrs_work
+    LAPACKE_ctpttf
+    LAPACKE_ctpttf_work
+    LAPACKE_ctpttr
+    LAPACKE_ctpttr_work
+    LAPACKE_ctrcon
+    LAPACKE_ctrcon_work
+    LAPACKE_ctrevc
+    LAPACKE_ctrevc_work
+    LAPACKE_ctrexc
+    LAPACKE_ctrexc_work
+    LAPACKE_ctrrfs
+    LAPACKE_ctrrfs_work
+    LAPACKE_ctrsen
+    LAPACKE_ctrsen_work
+    LAPACKE_ctrsna
+    LAPACKE_ctrsna_work
+    LAPACKE_ctrsyl
+    LAPACKE_ctrsyl_work
+    LAPACKE_ctrtri
+    LAPACKE_ctrtri_work
+    LAPACKE_ctrtrs
+    LAPACKE_ctrtrs_work
+    LAPACKE_ctrttf
+    LAPACKE_ctrttf_work
+    LAPACKE_ctrttp
+    LAPACKE_ctrttp_work
+    LAPACKE_ctzrzf
+    LAPACKE_ctzrzf_work
+    LAPACKE_cunbdb
+    LAPACKE_cunbdb_work
+    LAPACKE_cuncsd
+    LAPACKE_cuncsd_work
+    LAPACKE_cungbr
+    LAPACKE_cungbr_work
+    LAPACKE_cunghr
+    LAPACKE_cunghr_work
+    LAPACKE_cunglq
+    LAPACKE_cunglq_work
+    LAPACKE_cungql
+    LAPACKE_cungql_work
+    LAPACKE_cungqr
+    LAPACKE_cungqr_work
+    LAPACKE_cungrq
+    LAPACKE_cungrq_work
+    LAPACKE_cungtr
+    LAPACKE_cungtr_work
+    LAPACKE_cunmbr
+    LAPACKE_cunmbr_work
+    LAPACKE_cunmhr
+    LAPACKE_cunmhr_work
+    LAPACKE_cunmlq
+    LAPACKE_cunmlq_work
+    LAPACKE_cunmql
+    LAPACKE_cunmql_work
+    LAPACKE_cunmqr
+    LAPACKE_cunmqr_work
+    LAPACKE_cunmrq
+    LAPACKE_cunmrq_work
+    LAPACKE_cunmrz
+    LAPACKE_cunmrz_work
+    LAPACKE_cunmtr
+    LAPACKE_cunmtr_work
+    LAPACKE_cupgtr
+    LAPACKE_cupgtr_work
+    LAPACKE_cupmtr
+    LAPACKE_cupmtr_work
+    LAPACKE_csyr
+    LAPACKE_csyr_work
+    LAPACKE_clatms
+    LAPACKE_clatms_work
+    LAPACKE_clagge
+    LAPACKE_clagge_work
+    LAPACKE_claghe
+    LAPACKE_claghe_work
+    LAPACKE_clagsy
+    LAPACKE_clagsy_work
+    LAPACKE_cgejsv
+    LAPACKE_cgejsv_work
+    LAPACKE_cgesvdx
+    LAPACKE_cgesvdx_work
+    LAPACKE_cgesvj
+    LAPACKE_cgesvj_work
+    LAPACKE_cgetrf2
+    LAPACKE_cgetrf2_work
+    LAPACKE_cgges3
+    LAPACKE_cgges3_work
+    LAPACKE_cggev3
+    LAPACKE_cggev3_work
+    LAPACKE_cgghd3
+    LAPACKE_cgghd3_work
+    LAPACKE_cggsvd3
+    LAPACKE_cggsvd3_work
+    LAPACKE_cggsvp3
+    LAPACKE_cggsvp3_work
+    LAPACKE_chetrf_rook
+    LAPACKE_chetrf_rook_work
+    LAPACKE_chetrs_rook
+    LAPACKE_chetrs_rook_work
+    LAPACKE_clapmt
+    LAPACKE_clapmt_work
+    LAPACKE_clascl
+    LAPACKE_clascl_work
+    LAPACKE_cpotrf2
+    LAPACKE_cpotrf2_work
+    LAPACKE_csytrf_rook
+    LAPACKE_csytrf_rook_work
+    LAPACKE_csytrs_rook
+    LAPACKE_csytrs_rook_work
+    LAPACKE_cuncsd2by1
+    LAPACKE_cuncsd2by1_work
+    LAPACKE_cgelq
+    LAPACKE_cgelq_work
+    LAPACKE_cgemlq
+    LAPACKE_cgemlq_work
+    LAPACKE_cgemqr
+    LAPACKE_cgemqr_work
+    LAPACKE_cgeqr
+    LAPACKE_cgeqr_work
+    LAPACKE_cgetsls
+    LAPACKE_cgetsls_work
+    LAPACKE_chbev_2stage
+    LAPACKE_chbev_2stage_work
+    LAPACKE_chbevd_2stage
+    LAPACKE_chbevd_2stage_work
+    LAPACKE_chbevx_2stage
+    LAPACKE_chbevx_2stage_work
+    LAPACKE_checon_3
+    LAPACKE_checon_3_work
+    LAPACKE_cheev_2stage
+    LAPACKE_cheev_2stage_work
+    LAPACKE_cheevd_2stage
+    LAPACKE_cheevd_2stage_work
+    LAPACKE_cheevr_2stage
+    LAPACKE_cheevr_2stage_work
+    LAPACKE_cheevx_2stage
+    LAPACKE_cheevx_2stage_work
+    LAPACKE_chegv_2stage
+    LAPACKE_chegv_2stage_work
+    LAPACKE_chesv_aa
+    LAPACKE_chesv_aa_work
+    LAPACKE_chesv_rk
+    LAPACKE_chesv_rk_work
+    LAPACKE_chetrf_aa
+    LAPACKE_chetrf_aa_work
+    LAPACKE_chetrf_rk
+    LAPACKE_chetrf_rk_work
+    LAPACKE_chetri_3
+    LAPACKE_chetri_3_work
+    LAPACKE_chetrs_aa
+    LAPACKE_chetrs_aa_work
+    LAPACKE_chetrs_3
+    LAPACKE_chetrs_3_work
+    LAPACKE_csycon_3
+    LAPACKE_csycon_3_work
+    LAPACKE_csysv_aa
+    LAPACKE_csysv_aa_work
+    LAPACKE_csysv_rk
+    LAPACKE_csysv_rk_work
+    LAPACKE_csytrf_aa
+    LAPACKE_csytrf_aa_work
+    LAPACKE_csytrf_rk
+    LAPACKE_csytrf_rk_work
+    LAPACKE_csytri_3
+    LAPACKE_csytri_3_work
+    LAPACKE_csytrs_aa
+    LAPACKE_csytrs_aa_work
+    LAPACKE_csytrs_3
+    LAPACKE_csytrs_3_work
+    LAPACKE_chesv_aa_2stage
+    LAPACKE_chesv_aa_2stage_work
+    LAPACKE_chetrf_aa_2stage
+    LAPACKE_chetrf_aa_2stage_work
+    LAPACKE_chetrs_aa_2stage
+    LAPACKE_chetrs_aa_2stage_work
+    LAPACKE_clacrm
+    LAPACKE_clacrm_work
+    LAPACKE_clarcm
+    LAPACKE_clarcm_work
+    LAPACKE_classq
+    LAPACKE_classq_work
+    LAPACKE_csysv_aa_2stage
+    LAPACKE_csysv_aa_2stage_work
+    LAPACKE_csytrf_aa_2stage
+    LAPACKE_csytrf_aa_2stage_work
+    LAPACKE_csytrs_aa_2stage
+    LAPACKE_csytrs_aa_2stage_work
+    LAPACKE_cgesvdq
+    LAPACKE_cgesvdq_work
+    LAPACKE_cgetsqrhrt
+    LAPACKE_cgetsqrhrt_work
+    LAPACKE_cungtsqr_row
+    LAPACKE_cungtsqr_row_work
+    LAPACKE_clangb
+    LAPACKE_clangb_work
+    LAPACKE_ctrsyl3
+    LAPACKE_ctrsyl3_work
+    LAPACKE_ctz_nancheck
+    LAPACKE_ctz_trans
+    LAPACKE_cunhr_col
+    LAPACKE_cunhr_col_work
+"
+
+lapackeobjsd="
+    LAPACKE_dgb_nancheck
+    LAPACKE_dgb_trans
+    LAPACKE_dge_nancheck
+    LAPACKE_dge_trans
+    LAPACKE_dgg_nancheck
+    LAPACKE_dgg_trans
+    LAPACKE_dgt_nancheck
+    LAPACKE_dhs_nancheck
+    LAPACKE_dhs_trans
+    LAPACKE_d_nancheck
+    LAPACKE_dpb_nancheck
+    LAPACKE_dpb_trans
+    LAPACKE_dpf_nancheck
+    LAPACKE_dpf_trans
+    LAPACKE_dpo_nancheck
+    LAPACKE_dpo_trans
+    LAPACKE_dpp_nancheck
+    LAPACKE_dpp_trans
+    LAPACKE_dpt_nancheck
+    LAPACKE_dsb_nancheck
+    LAPACKE_dsb_trans
+    LAPACKE_dsp_nancheck
+    LAPACKE_dsp_trans
+    LAPACKE_dst_nancheck
+    LAPACKE_dsy_nancheck
+    LAPACKE_dsy_trans
+    LAPACKE_dtb_nancheck
+    LAPACKE_dtb_trans
+    LAPACKE_dtf_nancheck
+    LAPACKE_dtf_trans
+    LAPACKE_dtp_nancheck
+    LAPACKE_dtp_trans
+    LAPACKE_dtr_nancheck
+    LAPACKE_dtr_trans
+    LAPACKE_dbbcsd
+    LAPACKE_dbbcsd_work
+    LAPACKE_dbdsdc
+    LAPACKE_dbdsdc_work
+    LAPACKE_dbdsqr
+    LAPACKE_dbdsqr_work
+    LAPACKE_ddisna
+    LAPACKE_ddisna_work
+    LAPACKE_dgbbrd
+    LAPACKE_dgbbrd_work
+    LAPACKE_dgbcon
+    LAPACKE_dgbcon_work
+    LAPACKE_dgbequ
+    LAPACKE_dgbequ_work
+    LAPACKE_dgbequb
+    LAPACKE_dgbequb_work
+    LAPACKE_dgbrfs
+    LAPACKE_dgbrfs_work
+    LAPACKE_dgbsv
+    LAPACKE_dgbsv_work
+    LAPACKE_dgbsvx
+    LAPACKE_dgbsvx_work
+    LAPACKE_dgbtrf
+    LAPACKE_dgbtrf_work
+    LAPACKE_dgbtrs
+    LAPACKE_dgbtrs_work
+    LAPACKE_dgebak
+    LAPACKE_dgebak_work
+    LAPACKE_dgebal
+    LAPACKE_dgebal_work
+    LAPACKE_dgebrd
+    LAPACKE_dgebrd_work
+    LAPACKE_dgecon
+    LAPACKE_dgecon_work
+    LAPACKE_dgedmd
+    LAPACKE_dgedmd_work
+    LAPACKE_dgedmdq
+    LAPACKE_dgedmdq_work
+    LAPACKE_dgeequ
+    LAPACKE_dgeequ_work
+    LAPACKE_dgeequb
+    LAPACKE_dgeequb_work
+    LAPACKE_dgees
+    LAPACKE_dgees_work
+    LAPACKE_dgeesx
+    LAPACKE_dgeesx_work
+    LAPACKE_dgeev
+    LAPACKE_dgeev_work
+    LAPACKE_dgeevx
+    LAPACKE_dgeevx_work
+    LAPACKE_dgehrd
+    LAPACKE_dgehrd_work
+    LAPACKE_dgejsv
+    LAPACKE_dgejsv_work
+    LAPACKE_dgelq2
+    LAPACKE_dgelq2_work
+    LAPACKE_dgelqf
+    LAPACKE_dgelqf_work
+    LAPACKE_dgels
+    LAPACKE_dgels_work
+    LAPACKE_dgelsd
+    LAPACKE_dgelsd_work
+    LAPACKE_dgelss
+    LAPACKE_dgelss_work
+    LAPACKE_dgelsy
+    LAPACKE_dgelsy_work
+    LAPACKE_dgemqrt
+    LAPACKE_dgemqrt_work
+    LAPACKE_dgeqlf
+    LAPACKE_dgeqlf_work
+    LAPACKE_dgeqp3
+    LAPACKE_dgeqp3_work
+    LAPACKE_dgeqr2
+    LAPACKE_dgeqr2_work
+    LAPACKE_dgeqrf
+    LAPACKE_dgeqrf_work
+    LAPACKE_dgeqrfp
+    LAPACKE_dgeqrfp_work
+    LAPACKE_dgeqrt
+    LAPACKE_dgeqrt2
+    LAPACKE_dgeqrt2_work
+    LAPACKE_dgeqrt3
+    LAPACKE_dgeqrt3_work
+    LAPACKE_dgeqrt_work
+    LAPACKE_dgerfs
+    LAPACKE_dgerfs_work
+    LAPACKE_dgerqf
+    LAPACKE_dgerqf_work
+    LAPACKE_dgesdd
+    LAPACKE_dgesdd_work
+    LAPACKE_dgesv
+    LAPACKE_dgesv_work
+    LAPACKE_dgesvd
+    LAPACKE_dgesvd_work
+    LAPACKE_dgesvj
+    LAPACKE_dgesvj_work
+    LAPACKE_dgesvx
+    LAPACKE_dgesvx_work
+    LAPACKE_dgetf2
+    LAPACKE_dgetf2_work
+    LAPACKE_dgetrf
+    LAPACKE_dgetrf_work
+    LAPACKE_dgetri
+    LAPACKE_dgetri_work
+    LAPACKE_dgetrs
+    LAPACKE_dgetrs_work
+    LAPACKE_dggbak
+    LAPACKE_dggbak_work
+    LAPACKE_dggbal
+    LAPACKE_dggbal_work
+    LAPACKE_dgges
+    LAPACKE_dgges_work
+    LAPACKE_dggesx
+    LAPACKE_dggesx_work
+    LAPACKE_dggev
+    LAPACKE_dggev_work
+    LAPACKE_dggevx
+    LAPACKE_dggevx_work
+    LAPACKE_dggglm
+    LAPACKE_dggglm_work
+    LAPACKE_dgghrd
+    LAPACKE_dgghrd_work
+    LAPACKE_dgglse
+    LAPACKE_dgglse_work
+    LAPACKE_dggqrf
+    LAPACKE_dggqrf_work
+    LAPACKE_dggrqf
+    LAPACKE_dggrqf_work
+    LAPACKE_dgtcon
+    LAPACKE_dgtcon_work
+    LAPACKE_dgtrfs
+    LAPACKE_dgtrfs_work
+    LAPACKE_dgtsv
+    LAPACKE_dgtsv_work
+    LAPACKE_dgtsvx
+    LAPACKE_dgtsvx_work
+    LAPACKE_dgttrf
+    LAPACKE_dgttrf_work
+    LAPACKE_dgttrs
+    LAPACKE_dgttrs_work
+    LAPACKE_dhgeqz
+    LAPACKE_dhgeqz_work
+    LAPACKE_dhsein
+    LAPACKE_dhsein_work
+    LAPACKE_dhseqr
+    LAPACKE_dhseqr_work
+    LAPACKE_dlacn2
+    LAPACKE_dlacn2_work
+    LAPACKE_dlacpy
+    LAPACKE_dlacpy_work
+    LAPACKE_dlag2s
+    LAPACKE_dlag2s_work
+    LAPACKE_dlamch
+    LAPACKE_dlamch_work
+    LAPACKE_dlange
+    LAPACKE_dlange_work
+    LAPACKE_dlansy
+    LAPACKE_dlansy_work
+    LAPACKE_dlantr
+    LAPACKE_dlantr_work
+    LAPACKE_dlapmr
+    LAPACKE_dlapmr_work
+    LAPACKE_dlapy2
+    LAPACKE_dlapy2_work
+    LAPACKE_dlapy3
+    LAPACKE_dlapy3_work
+    LAPACKE_dlarfb
+    LAPACKE_dlarfb_work
+    LAPACKE_dlarfg
+    LAPACKE_dlarfg_work
+    LAPACKE_dlarft
+    LAPACKE_dlarft_work
+    LAPACKE_dlarfx
+    LAPACKE_dlarfx_work
+    LAPACKE_dlarnv
+    LAPACKE_dlarnv_work
+    LAPACKE_dlartgp
+    LAPACKE_dlartgp_work
+    LAPACKE_dlartgs
+    LAPACKE_dlartgs_work
+    LAPACKE_dlaset
+    LAPACKE_dlaset_work
+    LAPACKE_dlasrt
+    LAPACKE_dlasrt_work
+    LAPACKE_dlaswp
+    LAPACKE_dlaswp_work
+    LAPACKE_dlauum
+    LAPACKE_dlauum_work
+    LAPACKE_dopgtr
+    LAPACKE_dopgtr_work
+    LAPACKE_dopmtr
+    LAPACKE_dopmtr_work
+    LAPACKE_dorbdb
+    LAPACKE_dorbdb_work
+    LAPACKE_dorcsd
+    LAPACKE_dorcsd_work
+    LAPACKE_dorgbr
+    LAPACKE_dorgbr_work
+    LAPACKE_dorghr
+    LAPACKE_dorghr_work
+    LAPACKE_dorglq
+    LAPACKE_dorglq_work
+    LAPACKE_dorgql
+    LAPACKE_dorgql_work
+    LAPACKE_dorgqr
+    LAPACKE_dorgqr_work
+    LAPACKE_dorgrq
+    LAPACKE_dorgrq_work
+    LAPACKE_dorgtr
+    LAPACKE_dorgtr_work
+    LAPACKE_dormbr
+    LAPACKE_dormbr_work
+    LAPACKE_dormhr
+    LAPACKE_dormhr_work
+    LAPACKE_dormlq
+    LAPACKE_dormlq_work
+    LAPACKE_dormql
+    LAPACKE_dormql_work
+    LAPACKE_dormqr
+    LAPACKE_dormqr_work
+    LAPACKE_dormrq
+    LAPACKE_dormrq_work
+    LAPACKE_dormrz
+    LAPACKE_dormrz_work
+    LAPACKE_dormtr
+    LAPACKE_dormtr_work
+    LAPACKE_dpbcon
+    LAPACKE_dpbcon_work
+    LAPACKE_dpbequ
+    LAPACKE_dpbequ_work
+    LAPACKE_dpbrfs
+    LAPACKE_dpbrfs_work
+    LAPACKE_dpbstf
+    LAPACKE_dpbstf_work
+    LAPACKE_dpbsv
+    LAPACKE_dpbsv_work
+    LAPACKE_dpbsvx
+    LAPACKE_dpbsvx_work
+    LAPACKE_dpbtrf
+    LAPACKE_dpbtrf_work
+    LAPACKE_dpbtrs
+    LAPACKE_dpbtrs_work
+    LAPACKE_dpftrf
+    LAPACKE_dpftrf_work
+    LAPACKE_dpftri
+    LAPACKE_dpftri_work
+    LAPACKE_dpftrs
+    LAPACKE_dpftrs_work
+    LAPACKE_dpocon
+    LAPACKE_dpocon_work
+    LAPACKE_dpoequ
+    LAPACKE_dpoequ_work
+    LAPACKE_dpoequb
+    LAPACKE_dpoequb_work
+    LAPACKE_dporfs
+    LAPACKE_dporfs_work
+    LAPACKE_dposv
+    LAPACKE_dposv_work
+    LAPACKE_dposvx
+    LAPACKE_dposvx_work
+    LAPACKE_dpotrf
+    LAPACKE_dpotrf_work
+    LAPACKE_dpotri
+    LAPACKE_dpotri_work
+    LAPACKE_dpotrs
+    LAPACKE_dpotrs_work
+    LAPACKE_dppcon
+    LAPACKE_dppcon_work
+    LAPACKE_dppequ
+    LAPACKE_dppequ_work
+    LAPACKE_dpprfs
+    LAPACKE_dpprfs_work
+    LAPACKE_dppsv
+    LAPACKE_dppsv_work
+    LAPACKE_dppsvx
+    LAPACKE_dppsvx_work
+    LAPACKE_dpptrf
+    LAPACKE_dpptrf_work
+    LAPACKE_dpptri
+    LAPACKE_dpptri_work
+    LAPACKE_dpptrs
+    LAPACKE_dpptrs_work
+    LAPACKE_dpstrf
+    LAPACKE_dpstrf_work
+    LAPACKE_dptcon
+    LAPACKE_dptcon_work
+    LAPACKE_dpteqr
+    LAPACKE_dpteqr_work
+    LAPACKE_dptrfs
+    LAPACKE_dptrfs_work
+    LAPACKE_dptsv
+    LAPACKE_dptsv_work
+    LAPACKE_dptsvx
+    LAPACKE_dptsvx_work
+    LAPACKE_dpttrf
+    LAPACKE_dpttrf_work
+    LAPACKE_dpttrs
+    LAPACKE_dpttrs_work
+    LAPACKE_dsbev
+    LAPACKE_dsbev_work
+    LAPACKE_dsbevd
+    LAPACKE_dsbevd_work
+    LAPACKE_dsbevx
+    LAPACKE_dsbevx_work
+    LAPACKE_dsbgst
+    LAPACKE_dsbgst_work
+    LAPACKE_dsbgv
+    LAPACKE_dsbgv_work
+    LAPACKE_dsbgvd
+    LAPACKE_dsbgvd_work
+    LAPACKE_dsbgvx
+    LAPACKE_dsbgvx_work
+    LAPACKE_dsbtrd
+    LAPACKE_dsbtrd_work
+    LAPACKE_dsfrk
+    LAPACKE_dsfrk_work
+    LAPACKE_dsgesv
+    LAPACKE_dsgesv_work
+    LAPACKE_dspcon
+    LAPACKE_dspcon_work
+    LAPACKE_dspev
+    LAPACKE_dspev_work
+    LAPACKE_dspevd
+    LAPACKE_dspevd_work
+    LAPACKE_dspevx
+    LAPACKE_dspevx_work
+    LAPACKE_dspgst
+    LAPACKE_dspgst_work
+    LAPACKE_dspgv
+    LAPACKE_dspgv_work
+    LAPACKE_dspgvd
+    LAPACKE_dspgvd_work
+    LAPACKE_dspgvx
+    LAPACKE_dspgvx_work
+    LAPACKE_dsposv
+    LAPACKE_dsposv_work
+    LAPACKE_dsprfs
+    LAPACKE_dsprfs_work
+    LAPACKE_dspsv
+    LAPACKE_dspsv_work
+    LAPACKE_dspsvx
+    LAPACKE_dspsvx_work
+    LAPACKE_dsptrd
+    LAPACKE_dsptrd_work
+    LAPACKE_dsptrf
+    LAPACKE_dsptrf_work
+    LAPACKE_dsptri
+    LAPACKE_dsptri_work
+    LAPACKE_dsptrs
+    LAPACKE_dsptrs_work
+    LAPACKE_dstebz
+    LAPACKE_dstebz_work
+    LAPACKE_dstedc
+    LAPACKE_dstedc_work
+    LAPACKE_dstegr
+    LAPACKE_dstegr_work
+    LAPACKE_dstein
+    LAPACKE_dstein_work
+    LAPACKE_dstemr
+    LAPACKE_dstemr_work
+    LAPACKE_dsteqr
+    LAPACKE_dsteqr_work
+    LAPACKE_dsterf
+    LAPACKE_dsterf_work
+    LAPACKE_dstev
+    LAPACKE_dstev_work
+    LAPACKE_dstevd
+    LAPACKE_dstevd_work
+    LAPACKE_dstevr
+    LAPACKE_dstevr_work
+    LAPACKE_dstevx
+    LAPACKE_dstevx_work
+    LAPACKE_dsycon
+    LAPACKE_dsycon_work
+    LAPACKE_dsyconv
+    LAPACKE_dsyconv_work
+    LAPACKE_dsyequb
+    LAPACKE_dsyequb_work
+    LAPACKE_dsyev
+    LAPACKE_dsyev_work
+    LAPACKE_dsyevd
+    LAPACKE_dsyevd_work
+    LAPACKE_dsyevr
+    LAPACKE_dsyevr_work
+    LAPACKE_dsyevx
+    LAPACKE_dsyevx_work
+    LAPACKE_dsygst
+    LAPACKE_dsygst_work
+    LAPACKE_dsygv
+    LAPACKE_dsygv_work
+    LAPACKE_dsygvd
+    LAPACKE_dsygvd_work
+    LAPACKE_dsygvx
+    LAPACKE_dsygvx_work
+    LAPACKE_dsyrfs
+    LAPACKE_dsyrfs_work
+    LAPACKE_dsysv
+    LAPACKE_dsysv_rook
+    LAPACKE_dsysv_rook_work
+    LAPACKE_dsysv_work
+    LAPACKE_dsysvx
+    LAPACKE_dsysvx_work
+    LAPACKE_dsyswapr
+    LAPACKE_dsyswapr_work
+    LAPACKE_dsytrd
+    LAPACKE_dsytrd_work
+    LAPACKE_dsytrf
+    LAPACKE_dsytrf_work
+    LAPACKE_dsytri
+    LAPACKE_dsytri2
+    LAPACKE_dsytri2_work
+    LAPACKE_dsytri2x
+    LAPACKE_dsytri2x_work
+    LAPACKE_dsytri_work
+    LAPACKE_dsytrs
+    LAPACKE_dsytrs2
+    LAPACKE_dsytrs2_work
+    LAPACKE_dsytrs_work
+    LAPACKE_dtbcon
+    LAPACKE_dtbcon_work
+    LAPACKE_dtbrfs
+    LAPACKE_dtbrfs_work
+    LAPACKE_dtbtrs
+    LAPACKE_dtbtrs_work
+    LAPACKE_dtfsm
+    LAPACKE_dtfsm_work
+    LAPACKE_dtftri
+    LAPACKE_dtftri_work
+    LAPACKE_dtfttp
+    LAPACKE_dtfttp_work
+    LAPACKE_dtfttr
+    LAPACKE_dtfttr_work
+    LAPACKE_dtgevc
+    LAPACKE_dtgevc_work
+    LAPACKE_dtgexc
+    LAPACKE_dtgexc_work
+    LAPACKE_dtgsen
+    LAPACKE_dtgsen_work
+    LAPACKE_dtgsja
+    LAPACKE_dtgsja_work
+    LAPACKE_dtgsna
+    LAPACKE_dtgsna_work
+    LAPACKE_dtgsyl
+    LAPACKE_dtgsyl_work
+    LAPACKE_dtpcon
+    LAPACKE_dtpcon_work
+    LAPACKE_dtpmqrt
+    LAPACKE_dtpmqrt_work
+    LAPACKE_dtpqrt
+    LAPACKE_dtpqrt2
+    LAPACKE_dtpqrt2_work
+    LAPACKE_dtpqrt_work
+    LAPACKE_dtprfb
+    LAPACKE_dtprfb_work
+    LAPACKE_dtprfs
+    LAPACKE_dtprfs_work
+    LAPACKE_dtptri
+    LAPACKE_dtptri_work
+    LAPACKE_dtptrs
+    LAPACKE_dtptrs_work
+    LAPACKE_dtpttf
+    LAPACKE_dtpttf_work
+    LAPACKE_dtpttr
+    LAPACKE_dtpttr_work
+    LAPACKE_dtrcon
+    LAPACKE_dtrcon_work
+    LAPACKE_dtrevc
+    LAPACKE_dtrevc_work
+    LAPACKE_dtrexc
+    LAPACKE_dtrexc_work
+    LAPACKE_dtrrfs
+    LAPACKE_dtrrfs_work
+    LAPACKE_dtrsen
+    LAPACKE_dtrsen_work
+    LAPACKE_dtrsna
+    LAPACKE_dtrsna_work
+    LAPACKE_dtrsyl
+    LAPACKE_dtrsyl_work
+    LAPACKE_dtrtri
+    LAPACKE_dtrtri_work
+    LAPACKE_dtrtrs
+    LAPACKE_dtrtrs_work
+    LAPACKE_dtrttf
+    LAPACKE_dtrttf_work
+    LAPACKE_dtrttp
+    LAPACKE_dtrttp_work
+    LAPACKE_dtzrzf
+    LAPACKE_dtzrzf_work
+    LAPACKE_dlatms
+    LAPACKE_dlatms_work
+    LAPACKE_dlagge
+    LAPACKE_dlagge_work
+    LAPACKE_dlagsy
+    LAPACKE_dlagsy_work
+    LAPACKE_dbdsvdx
+    LAPACKE_dbdsvdx_work
+    LAPACKE_dgesvdx
+    LAPACKE_dgesvdx_work
+    LAPACKE_dgetrf2
+    LAPACKE_dgetrf2_work
+    LAPACKE_dgges3
+    LAPACKE_dgges3_work
+    LAPACKE_dggev3
+    LAPACKE_dggev3_work
+    LAPACKE_dgghd3
+    LAPACKE_dgghd3_work
+    LAPACKE_dggsvd3
+    LAPACKE_dggsvd3_work
+    LAPACKE_dggsvp3
+    LAPACKE_dggsvp3_work
+    LAPACKE_dlapmt
+    LAPACKE_dlapmt_work
+    LAPACKE_dlascl
+    LAPACKE_dlascl_work
+    LAPACKE_dorcsd2by1
+    LAPACKE_dorcsd2by1_work
+    LAPACKE_dpotrf2
+    LAPACKE_dpotrf2_work
+    LAPACKE_dsytrf_rook
+    LAPACKE_dsytrf_rook_work
+    LAPACKE_dsytrs_rook
+    LAPACKE_dsytrs_rook_work
+    LAPACKE_dgelq
+    LAPACKE_dgelq_work
+    LAPACKE_dgemlq
+    LAPACKE_dgemlq_work
+    LAPACKE_dgemqr
+    LAPACKE_dgemqr_work
+    LAPACKE_dgeqr
+    LAPACKE_dgeqr_work
+    LAPACKE_dgetsls
+    LAPACKE_dgetsls_work
+    LAPACKE_dsbev_2stage
+    LAPACKE_dsbev_2stage_work
+    LAPACKE_dsbevd_2stage
+    LAPACKE_dsbevd_2stage_work
+    LAPACKE_dsbevx_2stage
+    LAPACKE_dsbevx_2stage_work
+    LAPACKE_dsycon_3
+    LAPACKE_dsycon_3_work
+    LAPACKE_dsyev_2stage
+    LAPACKE_dsyev_2stage_work
+    LAPACKE_dsyevd_2stage
+    LAPACKE_dsyevd_2stage_work
+    LAPACKE_dsyevr_2stage
+    LAPACKE_dsyevr_2stage_work
+    LAPACKE_dsyevx_2stage
+    LAPACKE_dsyevx_2stage_work
+    LAPACKE_dsygv_2stage
+    LAPACKE_dsygv_2stage_work
+    LAPACKE_dsysv_aa
+    LAPACKE_dsysv_aa_work
+    LAPACKE_dsysv_rk
+    LAPACKE_dsysv_rk_work
+    LAPACKE_dsytrf_aa
+    LAPACKE_dsytrf_aa_work
+    LAPACKE_dsytrf_rk
+    LAPACKE_dsytrf_rk_work
+    LAPACKE_dsytri_3
+    LAPACKE_dsytri_3_work
+    LAPACKE_dsytrs_aa
+    LAPACKE_dsytrs_aa_work
+    LAPACKE_dsytrs_3
+    LAPACKE_dsytrs_3_work
+    LAPACKE_dlassq
+    LAPACKE_dlassq_work
+    LAPACKE_dsysv_aa_2stage
+    LAPACKE_dsysv_aa_2stage_work
+    LAPACKE_dsytrf_aa_2stage
+    LAPACKE_dsytrf_aa_2stage_work
+    LAPACKE_dsytrs_aa_2stage
+    LAPACKE_dsytrs_aa_2stage_work
+    LAPACKE_dgesvdq
+    LAPACKE_dgesvdq_work
+    LAPACKE_slag2d
+    LAPACKE_slag2d_work
+    LAPACKE_dgetsqrhrt
+    LAPACKE_dgetsqrhrt_work
+    LAPACKE_dorgtsqr_row
+    LAPACKE_dorgtsqr_row_work
+    LAPACKE_dlangb
+    LAPACKE_dlangb_work
+    LAPACKE_dorhr_col
+    LAPACKE_dorhr_col_work
+    LAPACKE_dtrsyl3
+    LAPACKE_dtrsyl3_work
+    LAPACKE_dtz_nancheck
+    LAPACKE_dtz_trans
+"
+
+lapackeobjss="
+    LAPACKE_sgb_nancheck
+    LAPACKE_sgb_trans
+    LAPACKE_sge_nancheck
+    LAPACKE_sge_trans
+    LAPACKE_sgg_nancheck
+    LAPACKE_sgg_trans
+    LAPACKE_sgt_nancheck
+    LAPACKE_shs_nancheck
+    LAPACKE_shs_trans
+    LAPACKE_s_nancheck
+    LAPACKE_spb_nancheck
+    LAPACKE_spb_trans
+    LAPACKE_spf_nancheck
+    LAPACKE_spf_trans
+    LAPACKE_spo_nancheck
+    LAPACKE_spo_trans
+    LAPACKE_spp_nancheck
+    LAPACKE_spp_trans
+    LAPACKE_spt_nancheck
+    LAPACKE_ssb_nancheck
+    LAPACKE_ssb_trans
+    LAPACKE_ssp_nancheck
+    LAPACKE_ssp_trans
+    LAPACKE_sst_nancheck
+    LAPACKE_ssy_nancheck
+    LAPACKE_ssy_trans
+    LAPACKE_stb_nancheck
+    LAPACKE_stb_trans
+    LAPACKE_stf_nancheck
+    LAPACKE_stf_trans
+    LAPACKE_stp_nancheck
+    LAPACKE_stp_trans
+    LAPACKE_str_nancheck
+    LAPACKE_str_trans
+    LAPACKE_sbbcsd
+    LAPACKE_sbbcsd_work
+    LAPACKE_sbdsdc
+    LAPACKE_sbdsdc_work
+    LAPACKE_sbdsqr
+    LAPACKE_sbdsqr_work
+    LAPACKE_sdisna
+    LAPACKE_sdisna_work
+    LAPACKE_sgbbrd
+    LAPACKE_sgbbrd_work
+    LAPACKE_sgbcon
+    LAPACKE_sgbcon_work
+    LAPACKE_sgbequ
+    LAPACKE_sgbequ_work
+    LAPACKE_sgbequb
+    LAPACKE_sgbequb_work
+    LAPACKE_sgbrfs
+    LAPACKE_sgbrfs_work
+    LAPACKE_sgbsv
+    LAPACKE_sgbsv_work
+    LAPACKE_sgbsvx
+    LAPACKE_sgbsvx_work
+    LAPACKE_sgbtrf
+    LAPACKE_sgbtrf_work
+    LAPACKE_sgbtrs
+    LAPACKE_sgbtrs_work
+    LAPACKE_sgebak
+    LAPACKE_sgebak_work
+    LAPACKE_sgebal
+    LAPACKE_sgebal_work
+    LAPACKE_sgebrd
+    LAPACKE_sgebrd_work
+    LAPACKE_sgecon
+    LAPACKE_sgecon_work
+    LAPACKE_sgedmd
+    LAPACKE_sgedmd_work
+    LAPACKE_sgedmdq
+    LAPACKE_sgedmdq_work
+    LAPACKE_sgeequ
+    LAPACKE_sgeequ_work
+    LAPACKE_sgeequb
+    LAPACKE_sgeequb_work
+    LAPACKE_sgees
+    LAPACKE_sgees_work
+    LAPACKE_sgeesx
+    LAPACKE_sgeesx_work
+    LAPACKE_sgeev
+    LAPACKE_sgeev_work
+    LAPACKE_sgeevx
+    LAPACKE_sgeevx_work
+    LAPACKE_sgehrd
+    LAPACKE_sgehrd_work
+    LAPACKE_sgejsv
+    LAPACKE_sgejsv_work
+    LAPACKE_sgelq2
+    LAPACKE_sgelq2_work
+    LAPACKE_sgelqf
+    LAPACKE_sgelqf_work
+    LAPACKE_sgels
+    LAPACKE_sgels_work
+    LAPACKE_sgelsd
+    LAPACKE_sgelsd_work
+    LAPACKE_sgelss
+    LAPACKE_sgelss_work
+    LAPACKE_sgelsy
+    LAPACKE_sgelsy_work
+    LAPACKE_sgemqrt
+    LAPACKE_sgemqrt_work
+    LAPACKE_sgeqlf
+    LAPACKE_sgeqlf_work
+    LAPACKE_sgeqp3
+    LAPACKE_sgeqp3_work
+    LAPACKE_sgeqr2
+    LAPACKE_sgeqr2_work
+    LAPACKE_sgeqrf
+    LAPACKE_sgeqrf_work
+    LAPACKE_sgeqrfp
+    LAPACKE_sgeqrfp_work
+    LAPACKE_sgeqrt
+    LAPACKE_sgeqrt2
+    LAPACKE_sgeqrt2_work
+    LAPACKE_sgeqrt3
+    LAPACKE_sgeqrt3_work
+    LAPACKE_sgeqrt_work
+    LAPACKE_sgerfs
+    LAPACKE_sgerfs_work
+    LAPACKE_sgerqf
+    LAPACKE_sgerqf_work
+    LAPACKE_sgesdd
+    LAPACKE_sgesdd_work
+    LAPACKE_sgesv
+    LAPACKE_sgesv_work
+    LAPACKE_sgesvd
+    LAPACKE_sgesvd_work
+    LAPACKE_sgesvj
+    LAPACKE_sgesvj_work
+    LAPACKE_sgesvx
+    LAPACKE_sgesvx_work
+    LAPACKE_sgetf2
+    LAPACKE_sgetf2_work
+    LAPACKE_sgetrf
+    LAPACKE_sgetrf_work
+    LAPACKE_sgetri
+    LAPACKE_sgetri_work
+    LAPACKE_sgetrs
+    LAPACKE_sgetrs_work
+    LAPACKE_sggbak
+    LAPACKE_sggbak_work
+    LAPACKE_sggbal
+    LAPACKE_sggbal_work
+    LAPACKE_sgges
+    LAPACKE_sgges_work
+    LAPACKE_sggesx
+    LAPACKE_sggesx_work
+    LAPACKE_sggev
+    LAPACKE_sggev_work
+    LAPACKE_sggevx
+    LAPACKE_sggevx_work
+    LAPACKE_sggglm
+    LAPACKE_sggglm_work
+    LAPACKE_sgghrd
+    LAPACKE_sgghrd_work
+    LAPACKE_sgglse
+    LAPACKE_sgglse_work
+    LAPACKE_sggqrf
+    LAPACKE_sggqrf_work
+    LAPACKE_sggrqf
+    LAPACKE_sggrqf_work
+    LAPACKE_sgtcon
+    LAPACKE_sgtcon_work
+    LAPACKE_sgtrfs
+    LAPACKE_sgtrfs_work
+    LAPACKE_sgtsv
+    LAPACKE_sgtsv_work
+    LAPACKE_sgtsvx
+    LAPACKE_sgtsvx_work
+    LAPACKE_sgttrf
+    LAPACKE_sgttrf_work
+    LAPACKE_sgttrs
+    LAPACKE_sgttrs_work
+    LAPACKE_shgeqz
+    LAPACKE_shgeqz_work
+    LAPACKE_shsein
+    LAPACKE_shsein_work
+    LAPACKE_shseqr
+    LAPACKE_shseqr_work
+    LAPACKE_slacn2
+    LAPACKE_slacn2_work
+    LAPACKE_slacpy
+    LAPACKE_slacpy_work
+    LAPACKE_slamch
+    LAPACKE_slamch_work
+    LAPACKE_slange
+    LAPACKE_slange_work
+    LAPACKE_slansy
+    LAPACKE_slansy_work
+    LAPACKE_slantr
+    LAPACKE_slantr_work
+    LAPACKE_slapmr
+    LAPACKE_slapmr_work
+    LAPACKE_slapy2
+    LAPACKE_slapy2_work
+    LAPACKE_slapy3
+    LAPACKE_slapy3_work
+    LAPACKE_slarfb
+    LAPACKE_slarfb_work
+    LAPACKE_slarfg
+    LAPACKE_slarfg_work
+    LAPACKE_slarft
+    LAPACKE_slarft_work
+    LAPACKE_slarfx
+    LAPACKE_slarfx_work
+    LAPACKE_slarnv
+    LAPACKE_slarnv_work
+    LAPACKE_slartgp
+    LAPACKE_slartgp_work
+    LAPACKE_slartgs
+    LAPACKE_slartgs_work
+    LAPACKE_slaset
+    LAPACKE_slaset_work
+    LAPACKE_slasrt
+    LAPACKE_slasrt_work
+    LAPACKE_slaswp
+    LAPACKE_slaswp_work
+    LAPACKE_slauum
+    LAPACKE_slauum_work
+    LAPACKE_sopgtr
+    LAPACKE_sopgtr_work
+    LAPACKE_sopmtr
+    LAPACKE_sopmtr_work
+    LAPACKE_sorbdb
+    LAPACKE_sorbdb_work
+    LAPACKE_sorcsd
+    LAPACKE_sorcsd_work
+    LAPACKE_sorgbr
+    LAPACKE_sorgbr_work
+    LAPACKE_sorghr
+    LAPACKE_sorghr_work
+    LAPACKE_sorglq
+    LAPACKE_sorglq_work
+    LAPACKE_sorgql
+    LAPACKE_sorgql_work
+    LAPACKE_sorgqr
+    LAPACKE_sorgqr_work
+    LAPACKE_sorgrq
+    LAPACKE_sorgrq_work
+    LAPACKE_sorgtr
+    LAPACKE_sorgtr_work
+    LAPACKE_sormbr
+    LAPACKE_sormbr_work
+    LAPACKE_sormhr
+    LAPACKE_sormhr_work
+    LAPACKE_sormlq
+    LAPACKE_sormlq_work
+    LAPACKE_sormql
+    LAPACKE_sormql_work
+    LAPACKE_sormqr
+    LAPACKE_sormqr_work
+    LAPACKE_sormrq
+    LAPACKE_sormrq_work
+    LAPACKE_sormrz
+    LAPACKE_sormrz_work
+    LAPACKE_sormtr
+    LAPACKE_sormtr_work
+    LAPACKE_spbcon
+    LAPACKE_spbcon_work
+    LAPACKE_spbequ
+    LAPACKE_spbequ_work
+    LAPACKE_spbrfs
+    LAPACKE_spbrfs_work
+    LAPACKE_spbstf
+    LAPACKE_spbstf_work
+    LAPACKE_spbsv
+    LAPACKE_spbsv_work
+    LAPACKE_spbsvx
+    LAPACKE_spbsvx_work
+    LAPACKE_spbtrf
+    LAPACKE_spbtrf_work
+    LAPACKE_spbtrs
+    LAPACKE_spbtrs_work
+    LAPACKE_spftrf
+    LAPACKE_spftrf_work
+    LAPACKE_spftri
+    LAPACKE_spftri_work
+    LAPACKE_spftrs
+    LAPACKE_spftrs_work
+    LAPACKE_spocon
+    LAPACKE_spocon_work
+    LAPACKE_spoequ
+    LAPACKE_spoequ_work
+    LAPACKE_spoequb
+    LAPACKE_spoequb_work
+    LAPACKE_sporfs
+    LAPACKE_sporfs_work
+    LAPACKE_sposv
+    LAPACKE_sposv_work
+    LAPACKE_sposvx
+    LAPACKE_sposvx_work
+    LAPACKE_spotrf
+    LAPACKE_spotrf_work
+    LAPACKE_spotri
+    LAPACKE_spotri_work
+    LAPACKE_spotrs
+    LAPACKE_spotrs_work
+    LAPACKE_sppcon
+    LAPACKE_sppcon_work
+    LAPACKE_sppequ
+    LAPACKE_sppequ_work
+    LAPACKE_spprfs
+    LAPACKE_spprfs_work
+    LAPACKE_sppsv
+    LAPACKE_sppsv_work
+    LAPACKE_sppsvx
+    LAPACKE_sppsvx_work
+    LAPACKE_spptrf
+    LAPACKE_spptrf_work
+    LAPACKE_spptri
+    LAPACKE_spptri_work
+    LAPACKE_spptrs
+    LAPACKE_spptrs_work
+    LAPACKE_spstrf
+    LAPACKE_spstrf_work
+    LAPACKE_sptcon
+    LAPACKE_sptcon_work
+    LAPACKE_spteqr
+    LAPACKE_spteqr_work
+    LAPACKE_sptrfs
+    LAPACKE_sptrfs_work
+    LAPACKE_sptsv
+    LAPACKE_sptsv_work
+    LAPACKE_sptsvx
+    LAPACKE_sptsvx_work
+    LAPACKE_spttrf
+    LAPACKE_spttrf_work
+    LAPACKE_spttrs
+    LAPACKE_spttrs_work
+    LAPACKE_ssbev
+    LAPACKE_ssbev_work
+    LAPACKE_ssbevd
+    LAPACKE_ssbevd_work
+    LAPACKE_ssbevx
+    LAPACKE_ssbevx_work
+    LAPACKE_ssbgst
+    LAPACKE_ssbgst_work
+    LAPACKE_ssbgv
+    LAPACKE_ssbgv_work
+    LAPACKE_ssbgvd
+    LAPACKE_ssbgvd_work
+    LAPACKE_ssbgvx
+    LAPACKE_ssbgvx_work
+    LAPACKE_ssbtrd
+    LAPACKE_ssbtrd_work
+    LAPACKE_ssfrk
+    LAPACKE_ssfrk_work
+    LAPACKE_sspcon
+    LAPACKE_sspcon_work
+    LAPACKE_sspev
+    LAPACKE_sspev_work
+    LAPACKE_sspevd
+    LAPACKE_sspevd_work
+    LAPACKE_sspevx
+    LAPACKE_sspevx_work
+    LAPACKE_sspgst
+    LAPACKE_sspgst_work
+    LAPACKE_sspgv
+    LAPACKE_sspgv_work
+    LAPACKE_sspgvd
+    LAPACKE_sspgvd_work
+    LAPACKE_sspgvx
+    LAPACKE_sspgvx_work
+    LAPACKE_ssprfs
+    LAPACKE_ssprfs_work
+    LAPACKE_sspsv
+    LAPACKE_sspsv_work
+    LAPACKE_sspsvx
+    LAPACKE_sspsvx_work
+    LAPACKE_ssptrd
+    LAPACKE_ssptrd_work
+    LAPACKE_ssptrf
+    LAPACKE_ssptrf_work
+    LAPACKE_ssptri
+    LAPACKE_ssptri_work
+    LAPACKE_ssptrs
+    LAPACKE_ssptrs_work
+    LAPACKE_sstebz
+    LAPACKE_sstebz_work
+    LAPACKE_sstedc
+    LAPACKE_sstedc_work
+    LAPACKE_sstegr
+    LAPACKE_sstegr_work
+    LAPACKE_sstein
+    LAPACKE_sstein_work
+    LAPACKE_sstemr
+    LAPACKE_sstemr_work
+    LAPACKE_ssteqr
+    LAPACKE_ssteqr_work
+    LAPACKE_ssterf
+    LAPACKE_ssterf_work
+    LAPACKE_sstev
+    LAPACKE_sstev_work
+    LAPACKE_sstevd
+    LAPACKE_sstevd_work
+    LAPACKE_sstevr
+    LAPACKE_sstevr_work
+    LAPACKE_sstevx
+    LAPACKE_sstevx_work
+    LAPACKE_ssycon
+    LAPACKE_ssycon_work
+    LAPACKE_ssyconv
+    LAPACKE_ssyconv_work
+    LAPACKE_ssyequb
+    LAPACKE_ssyequb_work
+    LAPACKE_ssyev
+    LAPACKE_ssyev_work
+    LAPACKE_ssyevd
+    LAPACKE_ssyevd_work
+    LAPACKE_ssyevr
+    LAPACKE_ssyevr_work
+    LAPACKE_ssyevx
+    LAPACKE_ssyevx_work
+    LAPACKE_ssygst
+    LAPACKE_ssygst_work
+    LAPACKE_ssygv
+    LAPACKE_ssygv_work
+    LAPACKE_ssygvd
+    LAPACKE_ssygvd_work
+    LAPACKE_ssygvx
+    LAPACKE_ssygvx_work
+    LAPACKE_ssyrfs
+    LAPACKE_ssyrfs_work
+    LAPACKE_ssysv
+    LAPACKE_ssysv_rook
+    LAPACKE_ssysv_rook_work
+    LAPACKE_ssysv_work
+    LAPACKE_ssysvx
+    LAPACKE_ssysvx_work
+    LAPACKE_ssyswapr
+    LAPACKE_ssyswapr_work
+    LAPACKE_ssytrd
+    LAPACKE_ssytrd_work
+    LAPACKE_ssytrf
+    LAPACKE_ssytrf_work
+    LAPACKE_ssytri
+    LAPACKE_ssytri2
+    LAPACKE_ssytri2_work
+    LAPACKE_ssytri2x
+    LAPACKE_ssytri2x_work
+    LAPACKE_ssytri_work
+    LAPACKE_ssytrs
+    LAPACKE_ssytrs2
+    LAPACKE_ssytrs2_work
+    LAPACKE_ssytrs_work
+    LAPACKE_stbcon
+    LAPACKE_stbcon_work
+    LAPACKE_stbrfs
+    LAPACKE_stbrfs_work
+    LAPACKE_stbtrs
+    LAPACKE_stbtrs_work
+    LAPACKE_stfsm
+    LAPACKE_stfsm_work
+    LAPACKE_stftri
+    LAPACKE_stftri_work
+    LAPACKE_stfttp
+    LAPACKE_stfttp_work
+    LAPACKE_stfttr
+    LAPACKE_stfttr_work
+    LAPACKE_stgevc
+    LAPACKE_stgevc_work
+    LAPACKE_stgexc
+    LAPACKE_stgexc_work
+    LAPACKE_stgsen
+    LAPACKE_stgsen_work
+    LAPACKE_stgsja
+    LAPACKE_stgsja_work
+    LAPACKE_stgsna
+    LAPACKE_stgsna_work
+    LAPACKE_stgsyl
+    LAPACKE_stgsyl_work
+    LAPACKE_stpcon
+    LAPACKE_stpcon_work
+    LAPACKE_stpmqrt
+    LAPACKE_stpmqrt_work
+    LAPACKE_stpqrt2
+    LAPACKE_stpqrt2_work
+    LAPACKE_stprfb
+    LAPACKE_stprfb_work
+    LAPACKE_stprfs
+    LAPACKE_stprfs_work
+    LAPACKE_stptri
+    LAPACKE_stptri_work
+    LAPACKE_stptrs
+    LAPACKE_stptrs_work
+    LAPACKE_stpttf
+    LAPACKE_stpttf_work
+    LAPACKE_stpttr
+    LAPACKE_stpttr_work
+    LAPACKE_strcon
+    LAPACKE_strcon_work
+    LAPACKE_strevc
+    LAPACKE_strevc_work
+    LAPACKE_strexc
+    LAPACKE_strexc_work
+    LAPACKE_strrfs
+    LAPACKE_strrfs_work
+    LAPACKE_strsen
+    LAPACKE_strsen_work
+    LAPACKE_strsna
+    LAPACKE_strsna_work
+    LAPACKE_strsyl
+    LAPACKE_strsyl_work
+    LAPACKE_strtri
+    LAPACKE_strtri_work
+    LAPACKE_strtrs
+    LAPACKE_strtrs_work
+    LAPACKE_strttf
+    LAPACKE_strttf_work
+    LAPACKE_strttp
+    LAPACKE_strttp_work
+    LAPACKE_stzrzf
+    LAPACKE_stzrzf_work
+    LAPACKE_slatms
+    LAPACKE_slatms_work
+    LAPACKE_slagge
+    LAPACKE_slagge_work
+    LAPACKE_slagsy
+    LAPACKE_slagsy_work
+    LAPACKE_sbdsvdx
+    LAPACKE_sbdsvdx_work
+    LAPACKE_sgesvdx
+    LAPACKE_sgesvdx_work
+    LAPACKE_sgetrf2
+    LAPACKE_sgetrf2_work
+    LAPACKE_sgges3
+    LAPACKE_sgges3_work
+    LAPACKE_sggev3
+    LAPACKE_sggev3_work
+    LAPACKE_sgghd3
+    LAPACKE_sgghd3_work
+    LAPACKE_sggsvd3
+    LAPACKE_sggsvd3_work
+    LAPACKE_sggsvp3
+    LAPACKE_sggsvp3_work
+    LAPACKE_slapmt
+    LAPACKE_slapmt_work
+    LAPACKE_slascl
+    LAPACKE_slascl_work
+    LAPACKE_sorcsd2by1
+    LAPACKE_sorcsd2by1_work
+    LAPACKE_spotrf2
+    LAPACKE_spotrf2_work
+    LAPACKE_ssytrf_rook
+    LAPACKE_ssytrf_rook_work
+    LAPACKE_ssytrs_rook
+    LAPACKE_ssytrs_rook_work
+    LAPACKE_stpqrt
+    LAPACKE_stpqrt_work
+    LAPACKE_sgelq
+    LAPACKE_sgelq_work
+    LAPACKE_sgemlq
+    LAPACKE_sgemlq_work
+    LAPACKE_sgemqr
+    LAPACKE_sgemqr_work
+    LAPACKE_sgeqr
+    LAPACKE_sgeqr_work
+    LAPACKE_sgetsls
+    LAPACKE_sgetsls_work
+    LAPACKE_ssbev_2stage
+    LAPACKE_ssbev_2stage_work
+    LAPACKE_ssbevd_2stage
+    LAPACKE_ssbevd_2stage_work
+    LAPACKE_ssbevx_2stage
+    LAPACKE_ssbevx_2stage_work
+    LAPACKE_ssycon_3
+    LAPACKE_ssycon_3_work
+    LAPACKE_ssyev_2stage
+    LAPACKE_ssyev_2stage_work
+    LAPACKE_ssyevd_2stage
+    LAPACKE_ssyevd_2stage_work
+    LAPACKE_ssyevr_2stage
+    LAPACKE_ssyevr_2stage_work
+    LAPACKE_ssyevx_2stage
+    LAPACKE_ssyevx_2stage_work
+    LAPACKE_ssygv_2stage
+    LAPACKE_ssygv_2stage_work
+    LAPACKE_ssysv_aa
+    LAPACKE_ssysv_aa_work
+    LAPACKE_ssysv_rk
+    LAPACKE_ssysv_rk_work
+    LAPACKE_ssytrf_aa
+    LAPACKE_ssytrf_aa_work
+    LAPACKE_ssytrf_rk
+    LAPACKE_ssytrf_rk_work
+    LAPACKE_ssytri_3
+    LAPACKE_ssytri_3_work
+    LAPACKE_ssytrs_aa
+    LAPACKE_ssytrs_aa_work
+    LAPACKE_ssytrs_3
+    LAPACKE_ssytrs_3_work
+    LAPACKE_slassq
+    LAPACKE_slassq_work
+    LAPACKE_ssysv_aa_2stage
+    LAPACKE_ssysv_aa_2stage_work
+    LAPACKE_ssytrf_aa_2stage
+    LAPACKE_ssytrf_aa_2stage_work
+    LAPACKE_ssytrs_aa_2stage
+    LAPACKE_ssytrs_aa_2stage_work
+    LAPACKE_sgesvdq
+    LAPACKE_sgesvdq_work
+    LAPACKE_sgetsqrhrt
+    LAPACKE_sgetsqrhrt_work
+    LAPACKE_sorgtsqr_row
+    LAPACKE_sorgtsqr_row_work
+    LAPACKE_slangb
+    LAPACKE_slangb_work
+    LAPACKE_sorhr_col
+    LAPACKE_sorhr_col_work
+    LAPACKE_strsyl3
+    LAPACKE_strsyl3_work
+    LAPACKE_stz_nancheck
+    LAPACKE_stz_trans
+"
+
+lapackeobjsz="
+    LAPACKE_zgb_nancheck
+    LAPACKE_zgb_trans
+    LAPACKE_zge_nancheck
+    LAPACKE_zge_trans
+    LAPACKE_zgg_nancheck
+    LAPACKE_zgg_trans
+    LAPACKE_zgt_nancheck
+    LAPACKE_zhb_nancheck
+    LAPACKE_zhb_trans
+    LAPACKE_zhe_nancheck
+    LAPACKE_zhe_trans
+    LAPACKE_zhp_nancheck
+    LAPACKE_zhp_trans
+    LAPACKE_zhs_nancheck
+    LAPACKE_zhs_trans
+    LAPACKE_z_nancheck
+    LAPACKE_zpb_nancheck
+    LAPACKE_zpb_trans
+    LAPACKE_zpf_nancheck
+    LAPACKE_zpf_trans
+    LAPACKE_zpo_nancheck
+    LAPACKE_zpo_trans
+    LAPACKE_zpp_nancheck
+    LAPACKE_zpp_trans
+    LAPACKE_zpt_nancheck
+    LAPACKE_zsp_nancheck
+    LAPACKE_zsp_trans
+    LAPACKE_zst_nancheck
+    LAPACKE_zsy_nancheck
+    LAPACKE_zsy_trans
+    LAPACKE_ztb_nancheck
+    LAPACKE_ztb_trans
+    LAPACKE_ztf_nancheck
+    LAPACKE_ztf_trans
+    LAPACKE_ztp_nancheck
+    LAPACKE_ztp_trans
+    LAPACKE_ztr_nancheck
+    LAPACKE_ztr_trans
+    LAPACKE_zbbcsd
+    LAPACKE_zbbcsd_work
+    LAPACKE_zbdsqr
+    LAPACKE_zbdsqr_work
+    LAPACKE_zcgesv
+    LAPACKE_zcgesv_work
+    LAPACKE_zcposv
+    LAPACKE_zcposv_work
+    LAPACKE_zgbbrd
+    LAPACKE_zgbbrd_work
+    LAPACKE_zgbcon
+    LAPACKE_zgbcon_work
+    LAPACKE_zgbequ
+    LAPACKE_zgbequ_work
+    LAPACKE_zgbequb
+    LAPACKE_zgbequb_work
+    LAPACKE_zgbrfs
+    LAPACKE_zgbrfs_work
+    LAPACKE_zgbsv
+    LAPACKE_zgbsv_work
+    LAPACKE_zgbsvx
+    LAPACKE_zgbsvx_work
+    LAPACKE_zgbtrf
+    LAPACKE_zgbtrf_work
+    LAPACKE_zgbtrs
+    LAPACKE_zgbtrs_work
+    LAPACKE_zgebak
+    LAPACKE_zgebak_work
+    LAPACKE_zgebal
+    LAPACKE_zgebal_work
+    LAPACKE_zgebrd
+    LAPACKE_zgebrd_work
+    LAPACKE_zgecon
+    LAPACKE_zgecon_work
+    LAPACKE_zgedmd
+    LAPACKE_zgedmd_work
+    LAPACKE_zgedmdq
+    LAPACKE_zgedmdq_work
+    LAPACKE_zgeequ
+    LAPACKE_zgeequ_work
+    LAPACKE_zgeequb
+    LAPACKE_zgeequb_work
+    LAPACKE_zgees
+    LAPACKE_zgees_work
+    LAPACKE_zgeesx
+    LAPACKE_zgeesx_work
+    LAPACKE_zgeev
+    LAPACKE_zgeev_work
+    LAPACKE_zgeevx
+    LAPACKE_zgeevx_work
+    LAPACKE_zgehrd
+    LAPACKE_zgehrd_work
+    LAPACKE_zgelq2
+    LAPACKE_zgelq2_work
+    LAPACKE_zgelqf
+    LAPACKE_zgelqf_work
+    LAPACKE_zgels
+    LAPACKE_zgels_work
+    LAPACKE_zgelsd
+    LAPACKE_zgelsd_work
+    LAPACKE_zgelss
+    LAPACKE_zgelss_work
+    LAPACKE_zgelsy
+    LAPACKE_zgelsy_work
+    LAPACKE_zgemqrt
+    LAPACKE_zgemqrt_work
+    LAPACKE_zgeqlf
+    LAPACKE_zgeqlf_work
+    LAPACKE_zgeqp3
+    LAPACKE_zgeqp3_work
+    LAPACKE_zgeqr2
+    LAPACKE_zgeqr2_work
+    LAPACKE_zgeqrf
+    LAPACKE_zgeqrf_work
+    LAPACKE_zgeqrfp
+    LAPACKE_zgeqrfp_work
+    LAPACKE_zgeqrt
+    LAPACKE_zgeqrt2
+    LAPACKE_zgeqrt2_work
+    LAPACKE_zgeqrt3
+    LAPACKE_zgeqrt3_work
+    LAPACKE_zgeqrt_work
+    LAPACKE_zgerfs
+    LAPACKE_zgerfs_work
+    LAPACKE_zgerqf
+    LAPACKE_zgerqf_work
+    LAPACKE_zgesdd
+    LAPACKE_zgesdd_work
+    LAPACKE_zgesv
+    LAPACKE_zgesv_work
+    LAPACKE_zgesvd
+    LAPACKE_zgesvd_work
+    LAPACKE_zgesvx
+    LAPACKE_zgesvx_work
+    LAPACKE_zgetf2
+    LAPACKE_zgetf2_work
+    LAPACKE_zgetrf
+    LAPACKE_zgetrf_work
+    LAPACKE_zgetri
+    LAPACKE_zgetri_work
+    LAPACKE_zgetrs
+    LAPACKE_zgetrs_work
+    LAPACKE_zggbak
+    LAPACKE_zggbak_work
+    LAPACKE_zggbal
+    LAPACKE_zggbal_work
+    LAPACKE_zgges
+    LAPACKE_zgges_work
+    LAPACKE_zggesx
+    LAPACKE_zggesx_work
+    LAPACKE_zggev
+    LAPACKE_zggev_work
+    LAPACKE_zggevx
+    LAPACKE_zggevx_work
+    LAPACKE_zggglm
+    LAPACKE_zggglm_work
+    LAPACKE_zgghrd
+    LAPACKE_zgghrd_work
+    LAPACKE_zgglse
+    LAPACKE_zgglse_work
+    LAPACKE_zggqrf
+    LAPACKE_zggqrf_work
+    LAPACKE_zggrqf
+    LAPACKE_zggrqf_work
+    LAPACKE_zgtcon
+    LAPACKE_zgtcon_work
+    LAPACKE_zgtrfs
+    LAPACKE_zgtrfs_work
+    LAPACKE_zgtsv
+    LAPACKE_zgtsv_work
+    LAPACKE_zgtsvx
+    LAPACKE_zgtsvx_work
+    LAPACKE_zgttrf
+    LAPACKE_zgttrf_work
+    LAPACKE_zgttrs
+    LAPACKE_zgttrs_work
+    LAPACKE_zhbev
+    LAPACKE_zhbev_work
+    LAPACKE_zhbevd
+    LAPACKE_zhbevd_work
+    LAPACKE_zhbevx
+    LAPACKE_zhbevx_work
+    LAPACKE_zhbgst
+    LAPACKE_zhbgst_work
+    LAPACKE_zhbgv
+    LAPACKE_zhbgv_work
+    LAPACKE_zhbgvd
+    LAPACKE_zhbgvd_work
+    LAPACKE_zhbgvx
+    LAPACKE_zhbgvx_work
+    LAPACKE_zhbtrd
+    LAPACKE_zhbtrd_work
+    LAPACKE_zhecon
+    LAPACKE_zhecon_work
+    LAPACKE_zheequb
+    LAPACKE_zheequb_work
+    LAPACKE_zheev
+    LAPACKE_zheev_work
+    LAPACKE_zheevd
+    LAPACKE_zheevd_work
+    LAPACKE_zheevr
+    LAPACKE_zheevr_work
+    LAPACKE_zheevx
+    LAPACKE_zheevx_work
+    LAPACKE_zhegst
+    LAPACKE_zhegst_work
+    LAPACKE_zhegv
+    LAPACKE_zhegv_work
+    LAPACKE_zhegvd
+    LAPACKE_zhegvd_work
+    LAPACKE_zhegvx
+    LAPACKE_zhegvx_work
+    LAPACKE_zherfs
+    LAPACKE_zherfs_work
+    LAPACKE_zhesv
+    LAPACKE_zhesv_work
+    LAPACKE_zhesvx
+    LAPACKE_zhesvx_work
+    LAPACKE_zheswapr
+    LAPACKE_zheswapr_work
+    LAPACKE_zhetrd
+    LAPACKE_zhetrd_work
+    LAPACKE_zhetrf
+    LAPACKE_zhetrf_work
+    LAPACKE_zhetri
+    LAPACKE_zhetri2
+    LAPACKE_zhetri2_work
+    LAPACKE_zhetri2x
+    LAPACKE_zhetri2x_work
+    LAPACKE_zhetri_work
+    LAPACKE_zhetrs
+    LAPACKE_zhetrs2
+    LAPACKE_zhetrs2_work
+    LAPACKE_zhetrs_work
+    LAPACKE_zhfrk
+    LAPACKE_zhfrk_work
+    LAPACKE_zhgeqz
+    LAPACKE_zhgeqz_work
+    LAPACKE_zhpcon
+    LAPACKE_zhpcon_work
+    LAPACKE_zhpev
+    LAPACKE_zhpev_work
+    LAPACKE_zhpevd
+    LAPACKE_zhpevd_work
+    LAPACKE_zhpevx
+    LAPACKE_zhpevx_work
+    LAPACKE_zhpgst
+    LAPACKE_zhpgst_work
+    LAPACKE_zhpgv
+    LAPACKE_zhpgv_work
+    LAPACKE_zhpgvd
+    LAPACKE_zhpgvd_work
+    LAPACKE_zhpgvx
+    LAPACKE_zhpgvx_work
+    LAPACKE_zhprfs
+    LAPACKE_zhprfs_work
+    LAPACKE_zhpsv
+    LAPACKE_zhpsv_work
+    LAPACKE_zhpsvx
+    LAPACKE_zhpsvx_work
+    LAPACKE_zhptrd
+    LAPACKE_zhptrd_work
+    LAPACKE_zhptrf
+    LAPACKE_zhptrf_work
+    LAPACKE_zhptri
+    LAPACKE_zhptri_work
+    LAPACKE_zhptrs
+    LAPACKE_zhptrs_work
+    LAPACKE_zhsein
+    LAPACKE_zhsein_work
+    LAPACKE_zhseqr
+    LAPACKE_zhseqr_work
+    LAPACKE_zlacgv
+    LAPACKE_zlacgv_work
+    LAPACKE_zlacn2
+    LAPACKE_zlacn2_work
+    LAPACKE_zlacp2
+    LAPACKE_zlacp2_work
+    LAPACKE_zlacpy
+    LAPACKE_zlacpy_work
+    LAPACKE_zlag2c
+    LAPACKE_zlag2c_work
+    LAPACKE_zlange
+    LAPACKE_zlange_work
+    LAPACKE_zlanhe
+    LAPACKE_zlanhe_work
+    LAPACKE_zlansy
+    LAPACKE_zlansy_work
+    LAPACKE_zlantr
+    LAPACKE_zlantr_work
+    LAPACKE_zlapmr
+    LAPACKE_zlapmr_work
+    LAPACKE_zlarfb
+    LAPACKE_zlarfb_work
+    LAPACKE_zlarfg
+    LAPACKE_zlarfg_work
+    LAPACKE_zlarft
+    LAPACKE_zlarft_work
+    LAPACKE_zlarfx
+    LAPACKE_zlarfx_work
+    LAPACKE_zlarnv
+    LAPACKE_zlarnv_work
+    LAPACKE_zlaset
+    LAPACKE_zlaset_work
+    LAPACKE_zlaswp
+    LAPACKE_zlaswp_work
+    LAPACKE_zlauum
+    LAPACKE_zlauum_work
+    LAPACKE_zpbcon
+    LAPACKE_zpbcon_work
+    LAPACKE_zpbequ
+    LAPACKE_zpbequ_work
+    LAPACKE_zpbrfs
+    LAPACKE_zpbrfs_work
+    LAPACKE_zpbstf
+    LAPACKE_zpbstf_work
+    LAPACKE_zpbsv
+    LAPACKE_zpbsv_work
+    LAPACKE_zpbsvx
+    LAPACKE_zpbsvx_work
+    LAPACKE_zpbtrf
+    LAPACKE_zpbtrf_work
+    LAPACKE_zpbtrs
+    LAPACKE_zpbtrs_work
+    LAPACKE_zpftrf
+    LAPACKE_zpftrf_work
+    LAPACKE_zpftri
+    LAPACKE_zpftri_work
+    LAPACKE_zpftrs
+    LAPACKE_zpftrs_work
+    LAPACKE_zpocon
+    LAPACKE_zpocon_work
+    LAPACKE_zpoequ
+    LAPACKE_zpoequ_work
+    LAPACKE_zpoequb
+    LAPACKE_zpoequb_work
+    LAPACKE_zporfs
+    LAPACKE_zporfs_work
+    LAPACKE_zposv
+    LAPACKE_zposv_work
+    LAPACKE_zposvx
+    LAPACKE_zposvx_work
+    LAPACKE_zpotrf
+    LAPACKE_zpotrf_work
+    LAPACKE_zpotri
+    LAPACKE_zpotri_work
+    LAPACKE_zpotrs
+    LAPACKE_zpotrs_work
+    LAPACKE_zppcon
+    LAPACKE_zppcon_work
+    LAPACKE_zppequ
+    LAPACKE_zppequ_work
+    LAPACKE_zpprfs
+    LAPACKE_zpprfs_work
+    LAPACKE_zppsv
+    LAPACKE_zppsv_work
+    LAPACKE_zppsvx
+    LAPACKE_zppsvx_work
+    LAPACKE_zpptrf
+    LAPACKE_zpptrf_work
+    LAPACKE_zpptri
+    LAPACKE_zpptri_work
+    LAPACKE_zpptrs
+    LAPACKE_zpptrs_work
+    LAPACKE_zpstrf
+    LAPACKE_zpstrf_work
+    LAPACKE_zptcon
+    LAPACKE_zptcon_work
+    LAPACKE_zpteqr
+    LAPACKE_zpteqr_work
+    LAPACKE_zptrfs
+    LAPACKE_zptrfs_work
+    LAPACKE_zptsv
+    LAPACKE_zptsv_work
+    LAPACKE_zptsvx
+    LAPACKE_zptsvx_work
+    LAPACKE_zpttrf
+    LAPACKE_zpttrf_work
+    LAPACKE_zpttrs
+    LAPACKE_zpttrs_work
+    LAPACKE_zspcon
+    LAPACKE_zspcon_work
+    LAPACKE_zsprfs
+    LAPACKE_zsprfs_work
+    LAPACKE_zspsv
+    LAPACKE_zspsv_work
+    LAPACKE_zspsvx
+    LAPACKE_zspsvx_work
+    LAPACKE_zsptrf
+    LAPACKE_zsptrf_work
+    LAPACKE_zsptri
+    LAPACKE_zsptri_work
+    LAPACKE_zsptrs
+    LAPACKE_zsptrs_work
+    LAPACKE_zstedc
+    LAPACKE_zstedc_work
+    LAPACKE_zstegr
+    LAPACKE_zstegr_work
+    LAPACKE_zstein
+    LAPACKE_zstein_work
+    LAPACKE_zstemr
+    LAPACKE_zstemr_work
+    LAPACKE_zsteqr
+    LAPACKE_zsteqr_work
+    LAPACKE_zsycon
+    LAPACKE_zsycon_work
+    LAPACKE_zsyconv
+    LAPACKE_zsyconv_work
+    LAPACKE_zsyequb
+    LAPACKE_zsyequb_work
+    LAPACKE_zsyrfs
+    LAPACKE_zsyrfs_work
+    LAPACKE_zsysv
+    LAPACKE_zsysv_rook
+    LAPACKE_zsysv_rook_work
+    LAPACKE_zsysv_work
+    LAPACKE_zsysvx
+    LAPACKE_zsysvx_work
+    LAPACKE_zsyswapr
+    LAPACKE_zsyswapr_work
+    LAPACKE_zsytrf
+    LAPACKE_zsytrf_work
+    LAPACKE_zsytri
+    LAPACKE_zsytri2
+    LAPACKE_zsytri2_work
+    LAPACKE_zsytri2x
+    LAPACKE_zsytri2x_work
+    LAPACKE_zsytri_work
+    LAPACKE_zsytrs
+    LAPACKE_zsytrs2
+    LAPACKE_zsytrs2_work
+    LAPACKE_zsytrs_work
+    LAPACKE_ztbcon
+    LAPACKE_ztbcon_work
+    LAPACKE_ztbrfs
+    LAPACKE_ztbrfs_work
+    LAPACKE_ztbtrs
+    LAPACKE_ztbtrs_work
+    LAPACKE_ztfsm
+    LAPACKE_ztfsm_work
+    LAPACKE_ztftri
+    LAPACKE_ztftri_work
+    LAPACKE_ztfttp
+    LAPACKE_ztfttp_work
+    LAPACKE_ztfttr
+    LAPACKE_ztfttr_work
+    LAPACKE_ztgevc
+    LAPACKE_ztgevc_work
+    LAPACKE_ztgexc
+    LAPACKE_ztgexc_work
+    LAPACKE_ztgsen
+    LAPACKE_ztgsen_work
+    LAPACKE_ztgsja
+    LAPACKE_ztgsja_work
+    LAPACKE_ztgsna
+    LAPACKE_ztgsna_work
+    LAPACKE_ztgsyl
+    LAPACKE_ztgsyl_work
+    LAPACKE_ztpcon
+    LAPACKE_ztpcon_work
+    LAPACKE_ztpmqrt
+    LAPACKE_ztpmqrt_work
+    LAPACKE_ztpqrt
+    LAPACKE_ztpqrt2
+    LAPACKE_ztpqrt2_work
+    LAPACKE_ztpqrt_work
+    LAPACKE_ztprfb
+    LAPACKE_ztprfb_work
+    LAPACKE_ztprfs
+    LAPACKE_ztprfs_work
+    LAPACKE_ztptri
+    LAPACKE_ztptri_work
+    LAPACKE_ztptrs
+    LAPACKE_ztptrs_work
+    LAPACKE_ztpttf
+    LAPACKE_ztpttf_work
+    LAPACKE_ztpttr
+    LAPACKE_ztpttr_work
+    LAPACKE_ztrcon
+    LAPACKE_ztrcon_work
+    LAPACKE_ztrevc
+    LAPACKE_ztrevc_work
+    LAPACKE_ztrexc
+    LAPACKE_ztrexc_work
+    LAPACKE_ztrrfs
+    LAPACKE_ztrrfs_work
+    LAPACKE_ztrsen
+    LAPACKE_ztrsen_work
+    LAPACKE_ztrsna
+    LAPACKE_ztrsna_work
+    LAPACKE_ztrsyl
+    LAPACKE_ztrsyl_work
+    LAPACKE_ztrtri
+    LAPACKE_ztrtri_work
+    LAPACKE_ztrtrs
+    LAPACKE_ztrtrs_work
+    LAPACKE_ztrttf
+    LAPACKE_ztrttf_work
+    LAPACKE_ztrttp
+    LAPACKE_ztrttp_work
+    LAPACKE_ztzrzf
+    LAPACKE_ztzrzf_work
+    LAPACKE_zunbdb
+    LAPACKE_zunbdb_work
+    LAPACKE_zuncsd
+    LAPACKE_zuncsd_work
+    LAPACKE_zungbr
+    LAPACKE_zungbr_work
+    LAPACKE_zunghr
+    LAPACKE_zunghr_work
+    LAPACKE_zunglq
+    LAPACKE_zunglq_work
+    LAPACKE_zungql
+    LAPACKE_zungql_work
+    LAPACKE_zungqr
+    LAPACKE_zungqr_work
+    LAPACKE_zungrq
+    LAPACKE_zungrq_work
+    LAPACKE_zungtr
+    LAPACKE_zungtr_work
+    LAPACKE_zunmbr
+    LAPACKE_zunmbr_work
+    LAPACKE_zunmhr
+    LAPACKE_zunmhr_work
+    LAPACKE_zunmlq
+    LAPACKE_zunmlq_work
+    LAPACKE_zunmql
+    LAPACKE_zunmql_work
+    LAPACKE_zunmqr
+    LAPACKE_zunmqr_work
+    LAPACKE_zunmrq
+    LAPACKE_zunmrq_work
+    LAPACKE_zunmrz
+    LAPACKE_zunmrz_work
+    LAPACKE_zunmtr
+    LAPACKE_zunmtr_work
+    LAPACKE_zupgtr
+    LAPACKE_zupgtr_work
+    LAPACKE_zupmtr
+    LAPACKE_zupmtr_work
+    LAPACKE_zsyr
+    LAPACKE_zsyr_work
+    LAPACKE_zlatms
+    LAPACKE_zlatms_work
+    LAPACKE_zlagge
+    LAPACKE_zlagge_work
+    LAPACKE_zlaghe
+    LAPACKE_zlaghe_work
+    LAPACKE_zlagsy
+    LAPACKE_zlagsy_work
+    LAPACKE_zgejsv
+    LAPACKE_zgejsv_work
+    LAPACKE_zgesvdx
+    LAPACKE_zgesvdx_work
+    LAPACKE_zgesvj
+    LAPACKE_zgesvj_work
+    LAPACKE_zgetrf2
+    LAPACKE_zgetrf2_work
+    LAPACKE_zgges3
+    LAPACKE_zgges3_work
+    LAPACKE_zggev3
+    LAPACKE_zggev3_work
+    LAPACKE_zgghd3
+    LAPACKE_zgghd3_work
+    LAPACKE_zggsvd3
+    LAPACKE_zggsvd3_work
+    LAPACKE_zggsvp3
+    LAPACKE_zggsvp3_work
+    LAPACKE_zhetrf_rook
+    LAPACKE_zhetrf_rook_work
+    LAPACKE_zhetrs_rook
+    LAPACKE_zhetrs_rook_work
+    LAPACKE_zlapmt
+    LAPACKE_zlapmt_work
+    LAPACKE_zlascl
+    LAPACKE_zlascl_work
+    LAPACKE_zpotrf2
+    LAPACKE_zpotrf2_work
+    LAPACKE_zsytrf_rook
+    LAPACKE_zsytrf_rook_work
+    LAPACKE_zsytrs_rook
+    LAPACKE_zsytrs_rook_work
+    LAPACKE_zuncsd2by1
+    LAPACKE_zuncsd2by1_work
+    LAPACKE_zgelq
+    LAPACKE_zgelq_work
+    LAPACKE_zgemlq
+    LAPACKE_zgemlq_work
+    LAPACKE_zgemqr
+    LAPACKE_zgemqr_work
+    LAPACKE_zgeqr
+    LAPACKE_zgeqr_work
+    LAPACKE_zgetsls
+    LAPACKE_zgetsls_work
+    LAPACKE_zhbev_2stage
+    LAPACKE_zhbev_2stage_work
+    LAPACKE_zhbevd_2stage
+    LAPACKE_zhbevd_2stage_work
+    LAPACKE_zhbevx_2stage
+    LAPACKE_zhbevx_2stage_work
+    LAPACKE_zhecon_3
+    LAPACKE_zhecon_3_work
+    LAPACKE_zheev_2stage
+    LAPACKE_zheev_2stage_work
+    LAPACKE_zheevd_2stage
+    LAPACKE_zheevd_2stage_work
+    LAPACKE_zheevr_2stage
+    LAPACKE_zheevr_2stage_work
+    LAPACKE_zheevx_2stage
+    LAPACKE_zheevx_2stage_work
+    LAPACKE_zhegv_2stage
+    LAPACKE_zhegv_2stage_work
+    LAPACKE_zhesv_aa
+    LAPACKE_zhesv_aa_work
+    LAPACKE_zhesv_rk
+    LAPACKE_zhesv_rk_work
+    LAPACKE_zhetrf_aa
+    LAPACKE_zhetrf_aa_work
+    LAPACKE_zhetrf_rk
+    LAPACKE_zhetrf_rk_work
+    LAPACKE_zhetri_3
+    LAPACKE_zhetri_3_work
+    LAPACKE_zhetrs_aa
+    LAPACKE_zhetrs_aa_work
+    LAPACKE_zhetrs_3
+    LAPACKE_zhetrs_3_work
+    LAPACKE_zsycon_3
+    LAPACKE_zsycon_3_work
+    LAPACKE_zsysv_aa
+    LAPACKE_zsysv_aa_work
+    LAPACKE_zsysv_rk
+    LAPACKE_zsysv_rk_work
+    LAPACKE_zsytrf_aa
+    LAPACKE_zsytrf_aa_work
+    LAPACKE_zsytrf_rk
+    LAPACKE_zsytrf_rk_work
+    LAPACKE_zsytri_3
+    LAPACKE_zsytri_3_work
+    LAPACKE_zsytrs_aa
+    LAPACKE_zsytrs_aa_work
+    LAPACKE_zsytrs_3
+    LAPACKE_zsytrs_3_work
+    LAPACKE_zhesv_aa_2stage
+    LAPACKE_zhesv_aa_2stage_work
+    LAPACKE_zhetrf_aa_2stage
+    LAPACKE_zhetrf_aa_2stage_work
+    LAPACKE_zhetrs_aa_2stage
+    LAPACKE_zhetrs_aa_2stage_work
+    LAPACKE_zlacrm
+    LAPACKE_zlacrm_work
+    LAPACKE_zlarcm
+    LAPACKE_zlarcm_work
+    LAPACKE_zlassq
+    LAPACKE_zlassq_work
+    LAPACKE_zsysv_aa_2stage
+    LAPACKE_zsysv_aa_2stage_work
+    LAPACKE_zsytrf_aa_2stage
+    LAPACKE_zsytrf_aa_2stage_work
+    LAPACKE_zsytrs_aa_2stage
+    LAPACKE_zsytrs_aa_2stage_work
+    LAPACKE_zgesvdq
     LAPACKE_zgesvdq_work
-);
+    LAPACKE_zgetsqrhrt
+    LAPACKE_zgetsqrhrt_work
+    LAPACKE_zungtsqr_row
+    LAPACKE_zungtsqr_row_work
+    LAPACKE_zlangb
+    LAPACKE_zlangb_work
+    LAPACKE_ztrsyl3
+    LAPACKE_ztrsyl3_work
+    LAPACKE_ztz_nancheck
+    LAPACKE_ztz_trans
+    LAPACKE_zunhr_col
+    LAPACKE_zunhr_col_work
+"
+## @(SRCX_OBJ) from `lapack-3.4.1/lapacke/src/Makefile`
+## Not exported: requires LAPACKE_EXTENDED to be set and depends on the
+##               corresponding LAPACK extended precision routines.
+#LAPACKE_cgbrfsx,
+#LAPACKE_cporfsx,
+#LAPACKE_dgerfsx,
+#LAPACKE_sgbrfsx,
+#LAPACKE_ssyrfsx,
+#LAPACKE_zherfsx,
+#LAPACKE_cgbrfsx_work,
+#LAPACKE_cporfsx_work,
+#LAPACKE_dgerfsx_work,
+#LAPACKE_sgbrfsx_work,
+#LAPACKE_ssyrfsx_work,
+#LAPACKE_zherfsx_work,
+#LAPACKE_cgerfsx,
+#LAPACKE_csyrfsx,
+#LAPACKE_dporfsx,
+#LAPACKE_sgerfsx,
+#LAPACKE_zgbrfsx,
+#LAPACKE_zporfsx,
+#LAPACKE_cgerfsx_work,
+#LAPACKE_csyrfsx_work,
+#LAPACKE_dporfsx_work,
+#LAPACKE_sgerfsx_work,
+#LAPACKE_zgbrfsx_work,
+#LAPACKE_zporfsx_work,
+#LAPACKE_cherfsx,
+#LAPACKE_dgbrfsx,
+#LAPACKE_dsyrfsx,
+#LAPACKE_sporfsx,
+#LAPACKE_zgerfsx,
+#LAPACKE_zsyrfsx,
+#LAPACKE_cherfsx_work,
+#LAPACKE_dgbrfsx_work,
+#LAPACKE_dsyrfsx_work,
+#LAPACKE_sporfsx_work,
+#LAPACKE_zgerfsx_work,
+#LAPACKE_zsyrfsx_work,
+#LAPACKE_cgbsvxx,
+#LAPACKE_cposvxx,
+#LAPACKE_dgesvxx,
+#LAPACKE_sgbsvxx,
+#LAPACKE_ssysvxx,
+#LAPACKE_zhesvxx,
+#LAPACKE_cgbsvxx_work,
+#LAPACKE_cposvxx_work,
+#LAPACKE_dgesvxx_work,
+#LAPACKE_sgbsvxx_work,
+#LAPACKE_ssysvxx_work,
+#LAPACKE_zhesvxx_work,
+#LAPACKE_cgesvxx,
+#LAPACKE_csysvxx,
+#LAPACKE_dposvxx,
+#LAPACKE_sgesvxx,
+#LAPACKE_zgbsvxx,
+#LAPACKE_zposvxx,
+#LAPACKE_cgesvxx_work,
+#LAPACKE_csysvxx_work,
+#LAPACKE_dposvxx_work,
+#LAPACKE_sgesvxx_work,
+#LAPACKE_zgbsvxx_work,
+#LAPACKE_zposvxx_work,
+#LAPACKE_chesvxx,
+#LAPACKE_dgbsvxx,
+#LAPACKE_dsysvxx,
+#LAPACKE_sposvxx,
+#LAPACKE_zgesvxx,
+#LAPACKE_zsysvxx,
+#LAPACKE_chesvxx_work,
+#LAPACKE_dgbsvxx_work,
+#LAPACKE_dsysvxx_work,
+#LAPACKE_sposvxx_work,
+#LAPACKE_zgesvxx_work,
+#LAPACKE_zsysvxx_work,
+
+## @(MATGEN_OBJ) from `lapack-3.4.1/lapacke/src/Makefile`
+## Not exported: requires LAPACKE_TESTING to be set and depends on libtmg
+##               (see `lapack-3.4.1/TESTING/MATGEN`).
 
 #These function may need 2 underscores.
-@lapack_embeded_underscore_objs=(
-    xerbla_array, chla_transtype,
-    );
-@lapack_embeded_underscore_objs_s=(    
-     slasyf_rook,
-    ssytf2_rook, ssytrf_rook, ssytrs_rook,
-    ssytri_rook, ssycon_rook, ssysv_rook,
-    slasyf_rk, ssyconvf_rook, ssytf2_rk,
-    ssytrf_rk, ssytrs_3, ssytri_3,
-    ssytri_3x, ssycon_3, ssysv_rk,
-    slasyf_aa, ssysv_aa, ssytrf_aa,
-    ssytrs_aa, ssytrd_2stage, ssytrd_sy2sb,
-    ssytrd_sb2st, ssb2st_kernels, ssyevd_2stage,
-    ssyev_2stage, ssyevx_2stage, ssyevr_2stage,
-    ssbev_2stage, ssbevx_2stage, ssbevd_2stage,
-    ssygv_2stage, 
-    ssysv_aa_2stage, ssytrf_aa_2stage,
-    ssytrs_aa_2stage, 
-    slaorhr_col_getrfnp, slaorhr_col_getrfnp2, sorhr_col,
-);
-@lapack_embeded_underscore_objs_c=(    
-    chetf2_rook, chetrf_rook, chetri_rook,
-    chetrs_rook, checon_rook, chesv_rook,
-    clahef_rook, clasyf_rook,
-    csytf2_rook, csytrf_rook, csytrs_rook,
-    csytri_rook, csycon_rook, csysv_rook,
-    chetf2_rk,
-    chetrf_rk, chetri_3, chetri_3x,
-    chetrs_3, checon_3, chesv_rk,
-    chesv_aa, chetrf_aa, chetrs_aa,
-    clahef_aa, clahef_rk, clasyf_rk,
-    clasyf_aa, csytf2_rk, csytrf_rk,
-    csytrf_aa, csytrs_3, csytrs_aa,
-    csytri_3, csytri_3x, csycon_3,
-    csysv_rk, csysv_aa, csyconvf_rook,
-    chetrd_2stage, chetrd_he2hb, chetrd_hb2st,
-    chb2st_kernels, cheevd_2stage, cheev_2stage,
-    cheevx_2stage, cheevr_2stage, chbev_2stage,
-    chbevx_2stage, chbevd_2stage, chegv_2stage,
-    chesv_aa_2stage,
-    chetrf_aa_2stage, chetrs_aa_2stage,
-    csysv_aa_2stage, csytrf_aa_2stage,
-    csytrs_aa_2stage,
-    claunhr_col_getrfnp, claunhr_col_getrfnp2, cunhr_col,
-);
-@lapack_embeded_underscore_objs_d=(    
-    dlasyf_rook,
-    dsytf2_rook, dsytrf_rook, dsytrs_rook,
-    dsytri_rook, dsycon_rook, dsysv_rook,
-    dlasyf_rk, dsyconvf_rook,
-    dsytf2_rk, dsytrf_rk, dsytrs_3,
-    dsytri_3, dsytri_3x, dsycon_3,
-    dsysv_rk, dlasyf_aa, dsysv_aa,
-    dsytrf_aa, dsytrs_aa, dsytrd_2stage,
-    dsytrd_sy2sb, dsytrd_sb2st, dsb2st_kernels,
-    dsyevd_2stage, dsyev_2stage, dsyevx_2stage,
-    dsyevr_2stage, dsbev_2stage, dsbevx_2stage,
-    dsbevd_2stage, dsygv_2stage, 
-     dsysv_aa_2stage,
-    dsytrf_aa_2stage, dsytrs_aa_2stage,
-    dlaorhr_col_getrfnp, dlaorhr_col_getrfnp2, dorhr_col,
-);
-@lapack_embeded_underscore_objs_z=(    
-    zhetf2_rook, zhetrf_rook, zhetri_rook,
-    zhetrs_rook, zhecon_rook, zhesv_rook,
-    zlahef_rook, zlasyf_rook,
-    zsytf2_rook, zsytrf_rook, zsytrs_rook,
-    zsytri_rook, zsycon_rook, zsysv_rook,
-    zhetf2_rk, zhetrf_rk, zhetri_3,
-    zhetri_3x, zhetrs_3, zhecon_3,
-    zhesv_rk, zhesv_aa, zhetrf_aa,
-    zhetrs_aa, zlahef_aa, zlahef_rk,
-    zlasyf_rk, zlasyf_aa, zsyconvf_rook,
-    zsytrs_aa, zsytf2_rk, zsytrf_rk,
-    zsytrf_aa, zsytrs_3, zsytri_3,
-    zsytri_3x, zsycon_3, zsysv_rk,
-    zsysv_aa, zhetrd_2stage, zhetrd_he2hb,
-    zhetrd_hb2st, zhb2st_kernels, zheevd_2stage,
-    zheev_2stage, zheevx_2stage, zheevr_2stage,
-    zhbev_2stage, zhbevx_2stage, zhbevd_2stage,
-    zhegv_2stage,
-    zhesv_aa_2stage, zhetrf_aa_2stage,
-    zhetrs_aa_2stage, zsysv_aa_2stage,
-    zsytrf_aa_2stage, zsytrs_aa_2stage,
-    zlaunhr_col_getrfnp, zlaunhr_col_getrfnp2, zunhr_col
-);
+lapack_embeded_underscore_objs="
+    xerbla_array chla_transtype
+    "
+lapack_embeded_underscore_objs_s="
+     slasyf_rook
+    ssytf2_rook ssytrf_rook ssytrs_rook
+    ssytri_rook ssycon_rook ssysv_rook
+    slasyf_rk ssyconvf_rook ssytf2_rk
+    ssytrf_rk ssytrs_3 ssytri_3
+    ssytri_3x ssycon_3 ssysv_rk
+    slasyf_aa ssysv_aa ssytrf_aa
+    ssytrs_aa ssytrd_2stage ssytrd_sy2sb
+    ssytrd_sb2st ssb2st_kernels ssyevd_2stage
+    ssyev_2stage ssyevx_2stage ssyevr_2stage
+    ssbev_2stage ssbevx_2stage ssbevd_2stage
+    ssygv_2stage
+    ssysv_aa_2stage ssytrf_aa_2stage
+    ssytrs_aa_2stage
+    slaorhr_col_getrfnp slaorhr_col_getrfnp2 sorhr_col
+    slarfb_gett
+"
+lapack_embeded_underscore_objs_c="
+    chetf2_rook chetrf_rook chetri_rook
+    chetrs_rook checon_rook chesv_rook
+    clahef_rook clasyf_rook
+    csytf2_rook csytrf_rook csytrs_rook
+    csytri_rook csycon_rook csysv_rook
+    chetf2_rk
+    chetrf_rk chetri_3 chetri_3x
+    chetrs_3 checon_3 chesv_rk
+    chesv_aa chetrf_aa chetrs_aa
+    clahef_aa clahef_rk clasyf_rk
+    clasyf_aa csytf2_rk csytrf_rk
+    csytrf_aa csytrs_3 csytrs_aa
+    csytri_3 csytri_3x csycon_3
+    csysv_rk csysv_aa csyconvf_rook
+    chetrd_2stage chetrd_he2hb chetrd_hb2st
+    chb2st_kernels cheevd_2stage cheev_2stage
+    cheevx_2stage cheevr_2stage chbev_2stage
+    chbevx_2stage chbevd_2stage chegv_2stage
+    chesv_aa_2stage
+    chetrf_aa_2stage chetrs_aa_2stage
+    csysv_aa_2stage csytrf_aa_2stage
+    csytrs_aa_2stage
+    claunhr_col_getrfnp claunhr_col_getrfnp2 cunhr_col
+    clarfb_gett
+"
+lapack_embeded_underscore_objs_d="
+    dlasyf_rook
+    dsytf2_rook dsytrf_rook dsytrs_rook
+    dsytri_rook dsycon_rook dsysv_rook
+    dlasyf_rk dsyconvf_rook
+    dsytf2_rk dsytrf_rk dsytrs_3
+    dsytri_3 dsytri_3x dsycon_3
+    dsysv_rk dlasyf_aa dsysv_aa
+    dsytrf_aa dsytrs_aa dsytrd_2stage
+    dsytrd_sy2sb dsytrd_sb2st dsb2st_kernels
+    dsyevd_2stage dsyev_2stage dsyevx_2stage
+    dsyevr_2stage dsbev_2stage dsbevx_2stage
+    dsbevd_2stage dsygv_2stage
+     dsysv_aa_2stage
+    dsytrf_aa_2stage dsytrs_aa_2stage
+    dlaorhr_col_getrfnp dlaorhr_col_getrfnp2 dorhr_col
+    dlarfb_gett
+"
+lapack_embeded_underscore_objs_z="
+    zhetf2_rook zhetrf_rook zhetri_rook
+    zhetrs_rook zhecon_rook zhesv_rook
+    zlahef_rook zlasyf_rook
+    zsytf2_rook zsytrf_rook zsytrs_rook
+    zsytri_rook zsycon_rook zsysv_rook
+    zhetf2_rk zhetrf_rk zhetri_3
+    zhetri_3x zhetrs_3 zhecon_3
+    zhesv_rk zhesv_aa zhetrf_aa
+    zhetrs_aa zlahef_aa zlahef_rk
+    zlasyf_rk zlasyf_aa zsyconvf_rook
+    zsytrs_aa zsytf2_rk zsytrf_rk
+    zsytrf_aa zsytrs_3 zsytri_3
+    zsytri_3x zsycon_3 zsysv_rk
+    zsysv_aa zhetrd_2stage zhetrd_he2hb
+    zhetrd_hb2st zhb2st_kernels zheevd_2stage
+    zheev_2stage zheevx_2stage zheevr_2stage
+    zhbev_2stage zhbevx_2stage zhbevd_2stage
+    zhegv_2stage
+    zhesv_aa_2stage zhetrf_aa_2stage
+    zhetrs_aa_2stage zsysv_aa_2stage
+    zsytrf_aa_2stage zsytrs_aa_2stage
+    zlaunhr_col_getrfnp zlaunhr_col_getrfnp2 zunhr_col
+    zlarfb_gett
+"
 
+dirname=`pwd -P`/../lapack-netlib
 
-use File::Spec;
-use File::Basename;
-my $dirname = File::Spec->catfile(dirname(dirname(File::Spec->rel2abs(__FILE__))), "lapack-netlib");
+p1=$1
+p2=$2
+p3=$3
+p4=$4
+p5=$5
+p6=$6
+p7=$7
+p8=$8
+p9=$9
+shift
+p10=$9
+shift
+p11=$9
+shift
+p12=$9
+shift
+p13=$9
+shift
+p14=$9
+shift
+p15=$9
+shift
+p16=$9
+shift
+p17=$9
 
-if ($ARGV[12] == 1) {
-	@blasobjs = (@blasobjs, @bfblasobjs);
-	@cblasobjs = (@cblasobjs, @bfcblasobjs);
-}
-if ($ARGV[13] == 1) {
-	@blasobjs = (@blasobjs, @blasobjss);
-	@cblasobjs = (@cblasobjs, @cblasobjss);
-	@lapackobjs = (@lapackobjs, @lapackobjss);
-	@lapackobjs2 = (@lapackobjs2, @lapackobjs2s);
-	@lapackobjs2 = (@lapackobjs2, @lapackobjs2sc);
-	@lapackobjs2 = (@lapackobjs2, @lapackobjs2ds);
-	@lapack_deprecated_objs = (@lapack_deprecated_objs, @lapack_deprecated_objss);
-	@lapacke_deprecated_objs = (@lapacke_deprecated_objs, @lapacke_deprecated_objss);
-	@lapack_embeded_underscore_objs = (@lapack_embeded_underscore_objs,  @lapack_embeded_underscore_objs_s); 
-	@lapackeobjs = (@lapackeobjs, @lapackeobjss);
-}
-if ($ARGV[14] == 1) {
-	@blasobjs = (@blasobjs, @blasobjsd);
-	@cblasobjs = (@cblasobjs, @cblasobjsd);
-	@lapackobjs = (@lapackobjs, @lapackobjsd);
-	if ($ARGV[13] == 0) { 
-		@lapackobjs2 = (@lapackobjs2, @lapackobjs2ds);
-	}
-	@lapackobjs2 = (@lapackobjs2, @lapackobjs2d, @lapackobjs2dz);
-	@lapack_deprecated_objs = (@lapack_deprecated_objs, @lapack_deprecated_objsd);
-	@lapacke_deprecated_objs = (@lapacke_deprecated_objs, @lapacke_deprecated_objsd);
-	@lapack_embeded_underscore_objs = (@lapack_embeded_underscore_objs,  @lapack_embeded_underscore_objs_d);
-	@lapackeobjs = (@lapackeobjs, @lapackeobjsd);
-}
-if ($ARGV[15] == 1) {
-	@blasobjs = (@blasobjs, @blasobjsc);
-	@cblasobjs = (@cblasobjs, @cblasobjsc);
-	@gemm3mobjs = (@gemm3mobjs, @gemm3mobjsc);
-	@cblasgemm3mobjs = (@cblasgemm3mobjs, @cblasgemm3mobjsc);
-	@lapackobjs = (@lapackobjs, @lapackobjsc);
-	@lapackobjs2 = (@lapackobjs2, @lapackobjs2c, @lapackobjs2zc);
-	if ($ARGV[13] == 0) { 
-		@lapackobjs2 = (@lapackobjs2, @lapackobjs2sc);
-	}
-	@lapack_deprecated_objs = (@lapack_deprecated_objs, @lapack_deprecated_objsc);
-	@lapacke_deprecated_objs = (@lapacke_deprecated_objs, @lapacke_deprecated_objsc);
-	@lapack_embeded_underscore_objs = (@lapack_embeded_underscore_objs,  @lapack_embeded_underscore_objs_c);
-	@lapackeobjs = (@lapackeobjs, @lapackeobjsc);
-}
-if ($ARGV[16] == 1) {
-	@blasobjs = (@blasobjs, @blasobjsz);
-	@cblasobjs = (@cblasobjs, @cblasobjsz);
-	@gemm3mobjs = (@gemm3mobjs, @gemm3mobjsz);
-	@cblasgemm3mobjs = (@cblasgemm3mobjs, @cblasgemm3mobjsz);
-	@lapackobjs = (@lapackobjs, @lapackobjsz);
-	@lapackobjs2 = (@lapackobjs2, @lapackobjs2z);
-	if ($ARGV[15] == 0) { 
-		@lapackobjs2 = (@lapackobjs2, @lapackobjs2zc);
-	}
-	if ($ARGV[14] == 0) { 
-		@lapackobjs2 = (@lapackobjs2, @lapackobjs2dz);
-	}
-	@lapack_deprecated_objs = (@lapack_deprecated_objs, @lapack_deprecated_objsz);
-	@lapacke_deprecated_objs = (@lapacke_deprecated_objs, @lapacke_deprecated_objsz);
-	@lapack_embeded_underscore_objs = (@lapack_embeded_underscore_objs,  @lapack_embeded_underscore_objs_z);
-	@lapackeobjs = (@lapackeobjs, @lapackeobjsz);
-}
-if ($ARGV[8] == 1) {
+if [ $p13 -eq 1 ]; then
+	blasobjs="$blasobjs $bfblasobjs"
+	cblasobjs="$cblasobjs $bfcblasobjs"
+fi
+
+if [ $p14 -eq 1 ]; then
+	blasobjs="$blasobjs $blasobjss"
+	cblasobjs="$cblasobjs $cblasobjss"
+	lapackobjs="$lapackobjs $lapackobjss"
+	lapackobjs2="$lapackobjs2 $lapackobjs2s"
+	lapackobjs2="$lapackobjs2 $lapackobjs2sc"
+	lapackobjs2="$lapackobjs2 $lapackobjs2ds"
+	lapack_deprecated_objs="$lapack_deprecated_objs $lapack_deprecated_objss"
+	lapacke_deprecated_objs="$lapacke_deprecated_objs $lapacke_deprecated_objss"
+	lapack_embeded_underscore_objs="$lapack_embeded_underscore_objs  $lapack_embeded_underscore_objs_s"
+	lapackeobjs="$lapackeobjs $lapackeobjss"
+fi
+
+if [ $p15 -eq 1 ]; then
+	blasobjs="$blasobjs $blasobjsd"
+	cblasobjs="$cblasobjs $cblasobjsd"
+	lapackobjs="$lapackobjs $lapackobjsd"
+    if [ $p14 -eq 0 ]; then
+		lapackobjs2="$lapackobjs2 $lapackobjs2ds"
+	fi
+	lapackobjs2="$lapackobjs2 $lapackobjs2d $lapackobjs2dz"
+	lapack_deprecated_objs="$lapack_deprecated_objs $lapack_deprecated_objsd"
+	lapacke_deprecated_objs="$lapacke_deprecated_objs $lapacke_deprecated_objsd"
+	lapack_embeded_underscore_objs="$lapack_embeded_underscore_objs  $lapack_embeded_underscore_objs_d"
+	lapackeobjs="$lapackeobjs $lapackeobjsd"
+fi
+
+if [ $p16 -eq 1 ]; then
+	blasobjs="$blasobjs $blasobjsc"
+	cblasobjs="$cblasobjs $cblasobjsc"
+	gemm3mobjs="$gemm3mobjs $gemm3mobjsc"
+	cblasgemm3mobjs="$cblasgemm3mobjs $cblasgemm3mobjsc"
+	lapackobjs="$lapackobjs $lapackobjsc"
+	lapackobjs2="$lapackobjs2 $lapackobjs2c $lapackobjs2zc"
+    if [ $p14 -eq 0 ]; then
+		lapackobjs2="$lapackobjs2 $lapackobjs2sc"
+	fi
+	lapack_deprecated_objs="$lapack_deprecated_objs $lapack_deprecated_objsc"
+	lapacke_deprecated_objs="$lapacke_deprecated_objs $lapacke_deprecated_objsc"
+	lapack_embeded_underscore_objs="$lapack_embeded_underscore_objs  $lapack_embeded_underscore_objs_c"
+	lapackeobjs="$lapackeobjs $lapackeobjsc"
+fi
+
+if [ $p17 -eq 1 ]; then
+	blasobjs="$blasobjs $blasobjsz"
+	cblasobjs="$cblasobjs $cblasobjsz"
+	gemm3mobjs="$gemm3mobjs $gemm3mobjsz"
+	cblasgemm3mobjs="$cblasgemm3mobjs $cblasgemm3mobjsz"
+	lapackobjs="$lapackobjs $lapackobjsz"
+	lapackobjs2="$lapackobjs2 $lapackobjs2z"
+	if [ $p16 -eq 0 ]; then
+		lapackobjs2="$lapackobjs2 $lapackobjs2zc"
+	fi
+	if [ $p15 -eq 0 ]; then
+		lapackobjs2="$lapackobjs2 $lapackobjs2dz"
+	fi
+	lapack_deprecated_objs="$lapack_deprecated_objs $lapack_deprecated_objsz"
+	lapacke_deprecated_objs="$lapacke_deprecated_objs $lapacke_deprecated_objsz"
+	lapack_embeded_underscore_objs="$lapack_embeded_underscore_objs  $lapack_embeded_underscore_objs_z"
+	lapackeobjs="$lapackeobjs $lapackeobjsz"
+fi
+
+if [ $p9 -eq 1 ]; then
     #ONLY_CBLAS=1
-    @underscore_objs = (@misc_underscore_objs);
-} elsif ($ARGV[5] == 1) {
+    underscore_objs="$misc_underscore_objs"
+elif [ $p6 -eq 1 ]; then
     #NO_LAPACK=1
-    @underscore_objs = (@blasobjs, @misc_underscore_objs);
-} elsif (-d $dirname) {
-    if ($ARGV[7] == 0) {
+    underscore_objs="$blasobjs $misc_underscore_objs"
+elif [ -d "$dirname" ]; then
+    if [ $p8 -eq 0 ]; then
         # NEED2UNDERSCORES=0
         # Don't need 2 underscores
-        @underscore_objs = (@blasobjs, @lapackobjs, @lapackobjs2, @misc_underscore_objs, @lapack_embeded_underscore_objs);
-    } else {
+        underscore_objs="$blasobjs $lapackobjs $lapackobjs2 $misc_underscore_objs $lapack_embeded_underscore_objs"
+    else
         # Need 2 underscores
-        @underscore_objs = (@blasobjs, @lapackobjs, @lapackobjs2, @misc_underscore_objs);
-        @need_2underscore_objs = (@lapack_embeded_underscore_objs);
-    };
+        underscore_objs="$blasobjs $lapackobjs $lapackobjs2 $misc_underscore_objs"
+        need_2underscore_objs="$lapack_embeded_underscore_objs"
+    fi
 
-    if ($ARGV[11] == 1) {
+    if [ $p12 -eq 1 ]; then
         #BUILD_LAPACK_DEPRECATED=1
-        @underscore_objs = (@underscore_objs, @lapack_deprecated_objs);
-    }
-} else {
-    @underscore_objs = (@blasobjs, @lapackobjs, @lapackobjs2, @lapack_embeded_underscore_objs, @misc_underscore_objs);
-}
+        underscore_objs="$underscore_objs $lapack_deprecated_objs"
+    fi
+else
+    underscore_objs="$blasobjs $lapackobjs $misc_underscore_objs"
+fi
 
-if ($ARGV[8] == 1) {
-    #ONLY_CBLAS=1
-    @gemm3mobjs=();
-    @exblasobjs=();
-}
+if [ $p9 -eq 1 ]; then
+    # ONLY_CBLAS=1
+    gemm3mobjs=''
+    exblasobjs=''
+fi
 
-if ($ARGV[3] == 1) {
-    @underscore_objs = (@underscore_objs, @exblasobjs);
-};
+if [ $p4 -eq 1 ]; then
+    underscore_objs="$underscore_objs $exblasobjs"
+fi
 
-if ($ARGV[1] eq "x86_64") { @underscore_objs = (@underscore_objs, @gemm3mobjs); };
-if ($ARGV[1] eq "x86")    { @underscore_objs = (@underscore_objs, @gemm3mobjs); };
-if ($ARGV[1] eq "ia64")   { @underscore_objs = (@underscore_objs, @gemm3mobjs); };
-if ($ARGV[1] eq "MIPS")   { @underscore_objs = (@underscore_objs, @gemm3mobjs); };
+case $p2 in
+    x86_64|x86|ia64|MIPS)
+        underscore_objs="$underscore_objs $gemm3mobjs"
+    ;;
+esac
 
-if ($ARGV[4] == 0) {
-    @no_underscore_objs = (@cblasobjs, @misc_no_underscore_objs);
-    if ($ARGV[1] eq "x86_64") { @no_underscore_objs = (@no_underscore_objs, @cblasgemm3mobjs); };
-    if ($ARGV[1] eq "x86")    { @no_underscore_objs = (@no_underscore_objs, @cblasgemm3mobjs); };
-    if ($ARGV[1] eq "ia64")   { @no_underscore_objs = (@no_underscore_objs, @cblasgemm3mobjs); };
-    if ($ARGV[1] eq "MIPS")   { @no_underscore_objs = (@no_underscore_objs, @cblasgemm3mobjs); };
-}else{
-    #NO_CBLAS=1
-    @no_underscore_objs = (@misc_no_underscore_objs);
-}
-if ($ARGV[6] == 1) {
-    #NO_LAPACKE=1
-    @no_underscore_objs = (@no_underscore_objs);
-} else {
-    if ($ARGV[11] == 1) {
-        #BUILD_LAPACK_DEPRECATED=1
-        @no_underscore_objs = (@no_underscore_objs, @lapackeobjs, @lapacke_deprecated_objs);
-    } else {
-        @no_underscore_objs = (@no_underscore_objs, @lapackeobjs);
-    }
-}
+if [ $p5 -eq 0 ]; then
+    no_underscore_objs="$cblasobjs $misc_no_underscore_objs"
+    case $p2 in
+        x86_64|x86|ia64|MIPS)
+            no_underscore_objs="$no_underscore_objs $cblasgemm3mobjs"
+        ;;
+    esac
+else
+    # NO_CBLAS=1
+    no_underscore_objs="$misc_no_underscore_objs"
+fi
 
-@hplobjs  = (daxpy, dcopy, dscal, idamax, dgemv, dtrsv, dger, dgemm, dtrsm);
-@hplobjs2 = (HPL_dlaswp00N, HPL_dlaswp01N, HPL_dlaswp01T);
+if [ $p7 -ne 1 ]; then
+    if [ $p12 -eq 1 ]; then
+        # BUILD_LAPACK_DEPRECATED=1
+        no_underscore_objs="$no_underscore_objs $lapackeobjs $lapacke_deprecated_objs"
+    else
+        no_underscore_objs="$no_underscore_objs $lapackeobjs"
+    fi
+fi
 
-$bu = $ARGV[2];
+hplobjs="daxpy dcopy dscal idamax dgemv dtrsv dger dgemm dtrsm"
+#hplobjs2="HPL_dlaswp00N HPL_dlaswp01N HPL_dlaswp01T"
 
-$bu = "" if (($bu eq "0") || ($bu eq "1"));
+bu="$p3"
 
-$symbolprefix = $ARGV[9];
+if [ "$bu" = "0" ] || [ "$bu" = "1" ]; then
+    bu=""
+fi
 
-$symbolsuffix = $ARGV[10];
+symbolprefix=$p10
+symbolsuffix=$p11
 
-if ($ARGV[0] eq "osx") {
-    @underscore_objs = (@underscore_objs, @misc_common_objs);
-    @no_underscore_objs = (@no_underscore_objs, @misc_common_objs);
+case "$p1" in
+    osx)
+        underscore_objs="$underscore_objs $misc_common_objs"
+        no_underscore_objs="$no_underscore_objs $misc_common_objs"
 
-    foreach $objs (@underscore_objs) {
-        print "_", $symbolprefix, $objs, $bu, $symbolsuffix, "\n";
-    }
+        for obj in $underscore_objs; do
+            printf '_%s%s%s%s\n' "$symbolprefix" "$obj" "$bu" "$symbolsuffix"
+        done
 
-    foreach $objs (@need_2underscore_objs) {
-        print "_", $symbolprefix, $objs, $bu, $bu, $symbolsuffix, "\n";
-    }
+        for obj in $need_2underscore_objs; do
+            printf '_%s%s%s%s%s\n' "$symbolprefix" "$obj" "$bu" "$bu" "$symbolsuffix"
+        done
 
-    foreach $objs (@no_underscore_objs) {
-        print "_", $symbolprefix, $objs, $symbolsuffix, "\n";
-    }
-    exit(0);
-}
+        for obj in $no_underscore_objs; do
+            printf '_%s%s%s\n' "$symbolprefix" "$obj" "$symbolsuffix"
+        done
+    ;;
 
-if ($ARGV[0] eq "aix"){
-    @underscore_objs = (@underscore_objs, @misc_common_objs);
-    @no_underscore_objs = (@no_underscore_objs, @misc_common_objs);
+    aix)
+        underscore_objs="$underscore_objs $misc_common_objs"
+        no_underscore_objs="$no_underscore_objs $misc_common_objs"
 
-    foreach $objs (@underscore_objs) {
-        print $symbolprefix, $objs, $bu, $symbolsuffix, "\n";
-    }
+        for obj in $underscore_objs; do
+            printf '_%s%s%s%s\n' "$symbolprefix" "$obj" "$bu" "$symbolsuffix"
+        done
 
-    foreach $objs (@need_2underscore_objs) {
-        print $symbolprefix, $objs, $bu, $bu, $symbolsuffix, "\n";
-    }
+        for obj in $need_2underscore_objs; do
+            printf '_%s%s%s%s%s\n' "$symbolprefix" "$obj" "$bu" "$bu" "$symbolsuffix"
+        done
 
-    foreach $objs (@no_underscore_objs) {
-        print $symbolprefix, $objs, $symbolsuffix, "\n";
-    }
-    exit(0);
-}
+        for obj in $no_underscore_objs; do
+            printf '_%s%s%s\n' "$symbolprefix" "$obj" "$symbolsuffix"
+        done
+    ;;
 
-if ($ARGV[0] eq "objcopy") {
-    @underscore_objs = (@underscore_objs, @misc_common_objs);
-    @no_underscore_objs = (@no_underscore_objs, @misc_common_objs);
+    objcopy)
+        underscore_objs="$underscore_objs $misc_common_objs"
+        no_underscore_objs="$no_underscore_objs $misc_common_objs"
 
-    foreach $objs (@underscore_objs) {
-        print $objs, $bu, " ", $symbolprefix, $objs, $bu, $symbolsuffix, "\n";
-    }
+        for obj in $underscore_objs; do
+            printf '%s%s %s%s%s%s\n' "$obj" "$bu" \
+                "$symbolprefix" "$obj" "$bu" "$symbolsuffix"
+        done
 
-    foreach $objs (@need_2underscore_objs) {
-        print $objs, $bu, $bu, " ", $symbolprefix, $objs, $bu, $bu, $symbolsuffix, "\n";
-    }
+        for obj in $need_2underscore_objs; do
+            printf '%s%s%s %s%s%s%s%s\n' "$obj" "$bu" "$bu" \
+                "$symbolprefix" "$obj" "$bu" "$bu" "$symbolsuffix"
+        done
 
-    foreach $objs (@no_underscore_objs) {
-        print $objs, " ", $symbolprefix, $objs, $symbolsuffix, "\n";
-    }
-    exit(0);
-}
+        for obj in $no_underscore_objs; do
+            printf '%s %s%s%s\n' "$obj" "$symbolprefix" "$obj" "$symbolsuffix"
+        done
+    ;;
 
-if ($ARGV[0] eq "objconv") {
-    @underscore_objs = (@underscore_objs, @misc_common_objs);
-    @no_underscore_objs = (@no_underscore_objs, @misc_common_objs);
+    objconv)
+        underscore_objs="$underscore_objs $misc_common_objs"
+        no_underscore_objs="$no_underscore_objs $misc_common_objs"
 
-    foreach $objs (@underscore_objs) {
-        print "-nr:_", $objs, $bu, ":_", $symbolprefix, $objs, $bu, $symbolsuffix, "\n";
-    }
+        for obj in $underscore_objs; do
+            printf -- '-nr:_%s%s:_%s%s%s%s\n' "$obj" "$bu" \
+                "$symbolprefix" "$obj" "$bu" "$symbolsuffix"
+        done
 
-    foreach $objs (@need_2underscore_objs) {
-        print "-nr:_", $objs, $bu, $bu, ":_", $symbolprefix, $objs, $bu, $bu, $symbolsuffix, "\n";
-    }
+        for obj in $need_2underscore_objs; do
+            printf -- '-nr:_%s%s%s:_%s%s%s%s%s\n' "$obj" "$bu" "$bu" \
+                "$symbolprefix" "$obj" "$bu" "$bu" "$symbolsuffix"
+        done
 
-    foreach $objs (@no_underscore_objs) {
-        print "-nr:_", $objs, ":_", $symbolprefix, $objs, $symbolsuffix, "\n";
-    }
-    exit(0);
-}
+        for obj in $no_underscore_objs; do
+            printf -- '-nr:_%s:_%s%s%s\n' "$obj" \
+                "$symbolprefix" "$obj" "$symbolsuffix"
+        done
+    ;;
 
-if ($ARGV[0] eq "win2k"){
-    print "EXPORTS\n";
-    $count = 1;
+    win2k)
+        printf 'EXPORTS\n'
+        count=1
 
-    @no_underscore_objs = (@no_underscore_objs, @misc_common_objs);
+        no_underscore_objs="$no_underscore_objs $misc_common_objs"
 
-    foreach $objs (@underscore_objs) {
-        $uppercase = $objs;
-        $uppercase =~ tr/[a-z]/[A-Z]/;
-        print "\t",$symbolprefix, $objs, $symbolsuffix, "=$objs","_  \@", $count, "\n";
-        $count ++;
-        print "\t",$symbolprefix, $objs, "_", $symbolsuffix, "=$objs","_  \@", $count, "\n";
-        $count ++;
-        print "\t",$symbolprefix, $uppercase, $symbolsuffix, "=$objs", "_  \@", $count, "\n";
-        $count ++;
-    }
+        for obj in $underscore_objs; do
+            uppercase=`echo "$obj" | tr '[[:lower:]]' '[[:upper:]]'`
+            printf '\t%s%s%s=%s_ @%s\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+            printf '\t%s%s_%s=%s_ @%s\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+            printf '\t%s%s%s=%s_ @%s\n' \
+                "$symbolprefix" "$uppercase" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+        done
 
-    foreach $objs (@need_2underscore_objs) {
-        $uppercase = $objs;
-        $uppercase =~ tr/[a-z]/[A-Z]/;
-        print "\t",$symbolprefix, $objs, $symbolsuffix, "=$objs","__  \@", $count, "\n";
-        $count ++;
-        print "\t",$symbolprefix, $objs, "__", $symbolsuffix, "=$objs","__  \@", $count, "\n";
-        $count ++;
-        print "\t",$symbolprefix, $uppercase, $symbolsuffix, "=$objs", "__  \@", $count, "\n";
-        $count ++;
-    }
+        for obj in $need_2underscore_objs; do
+            uppercase=`echo "$obj" | tr '[[:lower:]]' '[[:upper:]]'`
+            printf '\t%s%s%s=%s__ @%s\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+            printf '\t%s%s__%s=%s__ @%s\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+            printf '\t%s%s%s=%s__ @%s\n' \
+                "$symbolprefix" "$uppercase" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+        done
 
-    #for misc_common_objs
-    foreach $objs (@misc_common_objs) {
-        $uppercase = $objs;
-        $uppercase =~ tr/[a-z]/[A-Z]/;
-        print "\t",$symbolprefix, $objs, "_", $symbolsuffix, "=$objs","_  \@", $count, "\n";
-        $count ++;
-        print "\t",$symbolprefix, $uppercase, $symbolsuffix, "=$objs", "_  \@", $count, "\n";
-        $count ++;
-    }
+        for obj in $misc_common_objs; do
+            uppercase=`echo "$obj" | tr '[[:lower:]]' '[[:upper:]]'`
+            printf '\t%s%s_%s=%s_ @%s\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+            printf '\t%s%s%s=%s_ @%s\n' \
+                "$symbolprefix" "$uppercase" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+        done
 
+        for obj in $no_underscore_objs; do
+            printf '\t%s%s%s=%s  @%s\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+        done
+    ;;
 
-    foreach $objs (@no_underscore_objs) {
-        print "\t",$symbolprefix,$objs,$symbolsuffix,"=$objs","  \@", $count, "\n";
-        $count ++;
-    }
+    win2khpl)
+        printf 'EXPORTS\n'
+        count=1
+        for obj in $hplobjs; do
+            uppercase=`echo "$obj" | tr '[[:lower:]]' '[[:upper:]]'`
+            printf '\t%s%s%s=%s_  @%s\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+            printf '\t%s%s_%s=%s_  @%s\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+            printf '\t%s%s%s=%s_  @%s\n' \
+                "$symbolprefix" "$uppercase" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+        done
+    ;;
 
-    exit(0);
-}
+    microsoft)
+        underscore_objs="$underscore_objs $misc_common_objs"
 
-if ($ARGV[0] eq "win2khpl") {
-    print "EXPORTS\n";
-    $count = 1;
-    foreach $objs (@hplobjs) {
-        $uppercase = $objs;
-        $uppercase =~ tr/[a-z]/[A-Z]/;
-        print "\t",$symbolprefix, $objs, $symbolsuffix, "=$objs","_  \@", $count, "\n";
-        $count ++;
-        print "\t",$symbolprefix, $objs, "_", $symbolsuffix, "=$objs","_  \@", $count, "\n";
-        $count ++;
-        print "\t",$symbolprefix, $uppercase, $symbolsuffix, "=$objs", "_  \@", $count, "\n";
-        $count ++;
-    }
+        printf 'EXPORTS\n'
+        count=1
+        for obj in $underscore_objs; do
+            uppercase=`echo "$obj" | tr '[[:lower:]]' '[[:upper:]]'`
+            printf '\t%s%s%s = %s_\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix" "$obj"
+            count=`expr $count + 1`
+            printf '\t%s%s_%s = %s_\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix" "$obj"
+            count=`expr $count + 1`
+            printf '\t%s%s%s = %s_\n' \
+                "$symbolprefix" "$uppercase" "$symbolsuffix" "$obj"
+            count=`expr $count + 1`
+            printf '\t%s%s_%s = %s_\n' \
+                "$symbolprefix" "$uppercase" "$symbolsuffix" "$obj"
+            count=`expr $count + 1`
+        done
 
-    exit(0);
-}
+        for obj in $need_2underscore_objs; do
+            uppercase=`echo "$obj" | tr '[[:lower:]]' '[[:upper:]]'`
+            printf '\t%s%s%s=%s__  @%s\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+            printf '\t%s%s__%s=%s__  @%s\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+            printf '\t%s%s%s=%s__  @%s\n' \
+                "$symbolprefix" "$uppercase" "$symbolsuffix" "$obj" "$count"
+            count=`expr $count + 1`
+        done
+    ;;
 
-if ($ARGV[0] eq "microsoft"){
-    @underscore_objs = (@underscore_objs, @misc_common_objs);
+    linktest)
 
-    print "EXPORTS\n";
-    $count = 1;
-    foreach $objs (@underscore_objs) {
-        $uppercase = $objs;
-        $uppercase =~ tr/[a-z]/[A-Z]/;
-        print "\t",$symbolprefix, $objs, $symbolsuffix, " = $objs","_\n";
-        $count ++;
-        print "\t",$symbolprefix, $objs, "\_", $symbolsuffix, " = $objs","_\n";
-        $count ++;
-        print "\t",$symbolprefix, $uppercase, $symbolsuffix, " = $objs","_\n";
-        $count ++;
-        print "\t",$symbolprefix, $uppercase, "\_", $symbolsuffix, " = $objs","_\n";
-        $count ++;
-    }
+        underscore_objs="$underscore_objs $misc_common_objs"
+        no_underscore_objs="$no_underscore_objs $misc_common_objs"
 
-    foreach $objs (@need_2underscore_objs) {
-        $uppercase = $objs;
-        $uppercase =~ tr/[a-z]/[A-Z]/;
-        print "\t",$symbolprefix, $objs, $symbolsuffix, "=$objs","__  \@", $count, "\n";
-        $count ++;
-        print "\t",$symbolprefix, $objs, "__", $symbolsuffix, "=$objs","__  \@", $count, "\n";
-        $count ++;
-        print "\t",$symbolprefix, $uppercase, $symbolsuffix, "=$objs", "__  \@", $count, "\n";
-        $count ++;
-    }
+        printf 'int main(void){\n'
+        for obj in $underscore_objs; do
+            [ "$obj" != "xerbla" ] && printf 'extern void %s%s%s%s();\n' \
+                "$symbolprefix" "$obj" "$bu" "$symbolsuffix"
+        done
 
-    exit(0);
-}
+        for obj in $need_2underscore_objs; do
+            printf 'extern void %s%s%s%s%s();\n' \
+                "$symbolprefix" "$obj" "$bu" "$bu" "$symbolsuffix"
+        done
 
-if ($ARGV[0] eq "linktest") {
-    @underscore_objs = (@underscore_objs, @misc_common_objs);
-    @no_underscore_objs = (@no_underscore_objs, @misc_common_objs);
+        for obj in $no_underscore_objs; do
+            printf 'extern void %s%s%s();\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix"
+        done
 
-    print "int main(void){\n";
-    foreach $objs (@underscore_objs) {
-        print $symbolprefix, $objs, $bu, $symbolsuffix, "();\n" if $objs ne "xerbla";
-    }
+        printf '\n'
+        for obj in $underscore_objs; do
+            [ "$obj" != "xerbla" ] && printf '%s%s%s%s();\n' \
+                "$symbolprefix" "$obj" "$bu" "$symbolsuffix"
+        done
 
-    foreach $objs (@need_2underscore_objs) {
-        print $symbolprefix, $objs, $bu, $bu, $symbolsuffix, "();\n";
-    }
+        for obj in $need_2underscore_objs; do
+            printf '%s%s%s%s%s();\n' \
+                "$symbolprefix" "$obj" "$bu" "$bu" "$symbolsuffix"
+        done
 
-    foreach $objs (@no_underscore_objs) {
-        print $symbolprefix, $objs, $symbolsuffix, "();\n";
-    }
+        for obj in $no_underscore_objs; do
+            printf '%s%s%s();\n' \
+                "$symbolprefix" "$obj" "$symbolsuffix"
+        done
 
-    print "return 0;}\n";
-    exit(0);
-}
+        printf 'return 0;}\n'
+    ;;
+esac

--- a/src/exported_funcs.inc
+++ b/src/exported_funcs.inc
@@ -37,6 +37,10 @@
     XX(LAPACKE_cgebrd_work) \
     XX(LAPACKE_cgecon) \
     XX(LAPACKE_cgecon_work) \
+    XX(LAPACKE_cgedmd) \
+    XX(LAPACKE_cgedmd_work) \
+    XX(LAPACKE_cgedmdq) \
+    XX(LAPACKE_cgedmdq_work) \
     XX(LAPACKE_cgeequ) \
     XX(LAPACKE_cgeequ_work) \
     XX(LAPACKE_cgeequb) \
@@ -103,6 +107,8 @@
     XX(LAPACKE_cgesv_work) \
     XX(LAPACKE_cgesvd) \
     XX(LAPACKE_cgesvd_work) \
+    XX(LAPACKE_cgesvdq) \
+    XX(LAPACKE_cgesvdq_work) \
     XX(LAPACKE_cgesvdx) \
     XX(LAPACKE_cgesvdx_work) \
     XX(LAPACKE_cgesvj) \
@@ -121,6 +127,8 @@
     XX(LAPACKE_cgetrs_work) \
     XX(LAPACKE_cgetsls) \
     XX(LAPACKE_cgetsls_work) \
+    XX(LAPACKE_cgetsqrhrt) \
+    XX(LAPACKE_cgetsqrhrt_work) \
     XX(LAPACKE_cgg_nancheck) \
     XX(LAPACKE_cgg_trans) \
     XX(LAPACKE_cggbak) \
@@ -336,6 +344,8 @@
     XX(LAPACKE_claghe_work) \
     XX(LAPACKE_clagsy) \
     XX(LAPACKE_clagsy_work) \
+    XX(LAPACKE_clangb) \
+    XX(LAPACKE_clangb_work) \
     XX(LAPACKE_clange) \
     XX(LAPACKE_clange_work) \
     XX(LAPACKE_clanhe) \
@@ -607,6 +617,8 @@
     XX(LAPACKE_ctrsna) \
     XX(LAPACKE_ctrsna_work) \
     XX(LAPACKE_ctrsyl) \
+    XX(LAPACKE_ctrsyl3) \
+    XX(LAPACKE_ctrsyl3_work) \
     XX(LAPACKE_ctrsyl_work) \
     XX(LAPACKE_ctrtri) \
     XX(LAPACKE_ctrtri_work) \
@@ -616,6 +628,8 @@
     XX(LAPACKE_ctrttf_work) \
     XX(LAPACKE_ctrttp) \
     XX(LAPACKE_ctrttp_work) \
+    XX(LAPACKE_ctz_nancheck) \
+    XX(LAPACKE_ctz_trans) \
     XX(LAPACKE_ctzrzf) \
     XX(LAPACKE_ctzrzf_work) \
     XX(LAPACKE_cunbdb) \
@@ -638,6 +652,10 @@
     XX(LAPACKE_cungrq_work) \
     XX(LAPACKE_cungtr) \
     XX(LAPACKE_cungtr_work) \
+    XX(LAPACKE_cungtsqr_row) \
+    XX(LAPACKE_cungtsqr_row_work) \
+    XX(LAPACKE_cunhr_col) \
+    XX(LAPACKE_cunhr_col_work) \
     XX(LAPACKE_cunmbr) \
     XX(LAPACKE_cunmbr_work) \
     XX(LAPACKE_cunmhr) \
@@ -699,6 +717,10 @@
     XX(LAPACKE_dgebrd_work) \
     XX(LAPACKE_dgecon) \
     XX(LAPACKE_dgecon_work) \
+    XX(LAPACKE_dgedmd) \
+    XX(LAPACKE_dgedmd_work) \
+    XX(LAPACKE_dgedmdq) \
+    XX(LAPACKE_dgedmdq_work) \
     XX(LAPACKE_dgeequ) \
     XX(LAPACKE_dgeequ_work) \
     XX(LAPACKE_dgeequb) \
@@ -785,6 +807,8 @@
     XX(LAPACKE_dgetrs_work) \
     XX(LAPACKE_dgetsls) \
     XX(LAPACKE_dgetsls_work) \
+    XX(LAPACKE_dgetsqrhrt) \
+    XX(LAPACKE_dgetsqrhrt_work) \
     XX(LAPACKE_dgg_nancheck) \
     XX(LAPACKE_dgg_trans) \
     XX(LAPACKE_dggbak) \
@@ -856,6 +880,8 @@
     XX(LAPACKE_dlagsy_work) \
     XX(LAPACKE_dlamch) \
     XX(LAPACKE_dlamch_work) \
+    XX(LAPACKE_dlangb) \
+    XX(LAPACKE_dlangb_work) \
     XX(LAPACKE_dlange) \
     XX(LAPACKE_dlange_work) \
     XX(LAPACKE_dlansy) \
@@ -922,6 +948,10 @@
     XX(LAPACKE_dorgrq_work) \
     XX(LAPACKE_dorgtr) \
     XX(LAPACKE_dorgtr_work) \
+    XX(LAPACKE_dorgtsqr_row) \
+    XX(LAPACKE_dorgtsqr_row_work) \
+    XX(LAPACKE_dorhr_col) \
+    XX(LAPACKE_dorhr_col_work) \
     XX(LAPACKE_dormbr) \
     XX(LAPACKE_dormbr_work) \
     XX(LAPACKE_dormhr) \
@@ -1257,6 +1287,8 @@
     XX(LAPACKE_dtrsna) \
     XX(LAPACKE_dtrsna_work) \
     XX(LAPACKE_dtrsyl) \
+    XX(LAPACKE_dtrsyl3) \
+    XX(LAPACKE_dtrsyl3_work) \
     XX(LAPACKE_dtrsyl_work) \
     XX(LAPACKE_dtrtri) \
     XX(LAPACKE_dtrtri_work) \
@@ -1266,6 +1298,8 @@
     XX(LAPACKE_dtrttf_work) \
     XX(LAPACKE_dtrttp) \
     XX(LAPACKE_dtrttp_work) \
+    XX(LAPACKE_dtz_nancheck) \
+    XX(LAPACKE_dtz_trans) \
     XX(LAPACKE_dtzrzf) \
     XX(LAPACKE_dtzrzf_work) \
     XX(LAPACKE_get_nancheck) \
@@ -1313,6 +1347,10 @@
     XX(LAPACKE_sgebrd_work) \
     XX(LAPACKE_sgecon) \
     XX(LAPACKE_sgecon_work) \
+    XX(LAPACKE_sgedmd) \
+    XX(LAPACKE_sgedmd_work) \
+    XX(LAPACKE_sgedmdq) \
+    XX(LAPACKE_sgedmdq_work) \
     XX(LAPACKE_sgeequ) \
     XX(LAPACKE_sgeequ_work) \
     XX(LAPACKE_sgeequb) \
@@ -1399,6 +1437,8 @@
     XX(LAPACKE_sgetrs_work) \
     XX(LAPACKE_sgetsls) \
     XX(LAPACKE_sgetsls_work) \
+    XX(LAPACKE_sgetsqrhrt) \
+    XX(LAPACKE_sgetsqrhrt_work) \
     XX(LAPACKE_sgg_nancheck) \
     XX(LAPACKE_sgg_trans) \
     XX(LAPACKE_sggbak) \
@@ -1470,6 +1510,8 @@
     XX(LAPACKE_slagsy_work) \
     XX(LAPACKE_slamch) \
     XX(LAPACKE_slamch_work) \
+    XX(LAPACKE_slangb) \
+    XX(LAPACKE_slangb_work) \
     XX(LAPACKE_slange) \
     XX(LAPACKE_slange_work) \
     XX(LAPACKE_slansy) \
@@ -1536,6 +1578,10 @@
     XX(LAPACKE_sorgrq_work) \
     XX(LAPACKE_sorgtr) \
     XX(LAPACKE_sorgtr_work) \
+    XX(LAPACKE_sorgtsqr_row) \
+    XX(LAPACKE_sorgtsqr_row_work) \
+    XX(LAPACKE_sorhr_col) \
+    XX(LAPACKE_sorhr_col_work) \
     XX(LAPACKE_sormbr) \
     XX(LAPACKE_sormbr_work) \
     XX(LAPACKE_sormhr) \
@@ -1867,6 +1913,8 @@
     XX(LAPACKE_strsna) \
     XX(LAPACKE_strsna_work) \
     XX(LAPACKE_strsyl) \
+    XX(LAPACKE_strsyl3) \
+    XX(LAPACKE_strsyl3_work) \
     XX(LAPACKE_strsyl_work) \
     XX(LAPACKE_strtri) \
     XX(LAPACKE_strtri_work) \
@@ -1876,6 +1924,8 @@
     XX(LAPACKE_strttf_work) \
     XX(LAPACKE_strttp) \
     XX(LAPACKE_strttp_work) \
+    XX(LAPACKE_stz_nancheck) \
+    XX(LAPACKE_stz_trans) \
     XX(LAPACKE_stzrzf) \
     XX(LAPACKE_stzrzf_work) \
     XX(LAPACKE_xerbla) \
@@ -1918,6 +1968,10 @@
     XX(LAPACKE_zgebrd_work) \
     XX(LAPACKE_zgecon) \
     XX(LAPACKE_zgecon_work) \
+    XX(LAPACKE_zgedmd) \
+    XX(LAPACKE_zgedmd_work) \
+    XX(LAPACKE_zgedmdq) \
+    XX(LAPACKE_zgedmdq_work) \
     XX(LAPACKE_zgeequ) \
     XX(LAPACKE_zgeequ_work) \
     XX(LAPACKE_zgeequb) \
@@ -2004,6 +2058,8 @@
     XX(LAPACKE_zgetrs_work) \
     XX(LAPACKE_zgetsls) \
     XX(LAPACKE_zgetsls_work) \
+    XX(LAPACKE_zgetsqrhrt) \
+    XX(LAPACKE_zgetsqrhrt_work) \
     XX(LAPACKE_zgg_nancheck) \
     XX(LAPACKE_zgg_trans) \
     XX(LAPACKE_zggbak) \
@@ -2219,6 +2275,8 @@
     XX(LAPACKE_zlaghe_work) \
     XX(LAPACKE_zlagsy) \
     XX(LAPACKE_zlagsy_work) \
+    XX(LAPACKE_zlangb) \
+    XX(LAPACKE_zlangb_work) \
     XX(LAPACKE_zlange) \
     XX(LAPACKE_zlange_work) \
     XX(LAPACKE_zlanhe) \
@@ -2490,6 +2548,8 @@
     XX(LAPACKE_ztrsna) \
     XX(LAPACKE_ztrsna_work) \
     XX(LAPACKE_ztrsyl) \
+    XX(LAPACKE_ztrsyl3) \
+    XX(LAPACKE_ztrsyl3_work) \
     XX(LAPACKE_ztrsyl_work) \
     XX(LAPACKE_ztrtri) \
     XX(LAPACKE_ztrtri_work) \
@@ -2499,6 +2559,8 @@
     XX(LAPACKE_ztrttf_work) \
     XX(LAPACKE_ztrttp) \
     XX(LAPACKE_ztrttp_work) \
+    XX(LAPACKE_ztz_nancheck) \
+    XX(LAPACKE_ztz_trans) \
     XX(LAPACKE_ztzrzf) \
     XX(LAPACKE_ztzrzf_work) \
     XX(LAPACKE_zunbdb) \
@@ -2521,6 +2583,10 @@
     XX(LAPACKE_zungrq_work) \
     XX(LAPACKE_zungtr) \
     XX(LAPACKE_zungtr_work) \
+    XX(LAPACKE_zungtsqr_row) \
+    XX(LAPACKE_zungtsqr_row_work) \
+    XX(LAPACKE_zunhr_col) \
+    XX(LAPACKE_zunhr_col_work) \
     XX(LAPACKE_zunmbr) \
     XX(LAPACKE_zunmbr_work) \
     XX(LAPACKE_zunmhr) \
@@ -2543,10 +2609,9 @@
     XX(LAPACKE_zupmtr_work) \
     XX(caxpby_) \
     XX(caxpy_) \
-    XX(cbbcsd_) \
-    XX(cbdsqr_) \
     XX(cblas_caxpby) \
     XX(cblas_caxpy) \
+    XX(cblas_caxpyc) \
     XX(cblas_ccopy) \
     XX(cblas_cdotc) \
     XX(cblas_cdotc_sub) \
@@ -2556,6 +2621,7 @@
     XX(cblas_cgeadd) \
     XX(cblas_cgemm) \
     XX(cblas_cgemm3m) \
+    XX(cblas_cgemmt) \
     XX(cblas_cgemv) \
     XX(cblas_cgerc) \
     XX(cblas_cgeru) \
@@ -2571,7 +2637,9 @@
     XX(cblas_chpr2) \
     XX(cblas_cimatcopy) \
     XX(cblas_comatcopy) \
+    XX(cblas_crotg) \
     XX(cblas_cscal) \
+    XX(cblas_csrot) \
     XX(cblas_csscal) \
     XX(cblas_cswap) \
     XX(cblas_csymm) \
@@ -2585,6 +2653,8 @@
     XX(cblas_ctrmv) \
     XX(cblas_ctrsm) \
     XX(cblas_ctrsv) \
+    XX(cblas_damax) \
+    XX(cblas_damin) \
     XX(cblas_dasum) \
     XX(cblas_daxpby) \
     XX(cblas_daxpy) \
@@ -2594,6 +2664,7 @@
     XX(cblas_dgbmv) \
     XX(cblas_dgeadd) \
     XX(cblas_dgemm) \
+    XX(cblas_dgemmt) \
     XX(cblas_dgemv) \
     XX(cblas_dger) \
     XX(cblas_dimatcopy) \
@@ -2625,6 +2696,8 @@
     XX(cblas_dtrmv) \
     XX(cblas_dtrsm) \
     XX(cblas_dtrsv) \
+    XX(cblas_dzamax) \
+    XX(cblas_dzamin) \
     XX(cblas_dzasum) \
     XX(cblas_dznrm2) \
     XX(cblas_dzsum) \
@@ -2644,6 +2717,8 @@
     XX(cblas_izamin) \
     XX(cblas_izmax) \
     XX(cblas_izmin) \
+    XX(cblas_samax) \
+    XX(cblas_samin) \
     XX(cblas_sasum) \
     XX(cblas_saxpby) \
     XX(cblas_saxpy) \
@@ -2653,6 +2728,8 @@
     XX(cblas_sbgemm) \
     XX(cblas_sbgemv) \
     XX(cblas_sbstobf16) \
+    XX(cblas_scamax) \
+    XX(cblas_scamin) \
     XX(cblas_scasum) \
     XX(cblas_scnrm2) \
     XX(cblas_scopy) \
@@ -2662,6 +2739,7 @@
     XX(cblas_sgbmv) \
     XX(cblas_sgeadd) \
     XX(cblas_sgemm) \
+    XX(cblas_sgemmt) \
     XX(cblas_sgemv) \
     XX(cblas_sger) \
     XX(cblas_simatcopy) \
@@ -2695,16 +2773,19 @@
     XX(cblas_xerbla) \
     XX(cblas_zaxpby) \
     XX(cblas_zaxpy) \
+    XX(cblas_zaxpyc) \
     XX(cblas_zcopy) \
     XX(cblas_zdotc) \
     XX(cblas_zdotc_sub) \
     XX(cblas_zdotu) \
     XX(cblas_zdotu_sub) \
+    XX(cblas_zdrot) \
     XX(cblas_zdscal) \
     XX(cblas_zgbmv) \
     XX(cblas_zgeadd) \
     XX(cblas_zgemm) \
     XX(cblas_zgemm3m) \
+    XX(cblas_zgemmt) \
     XX(cblas_zgemv) \
     XX(cblas_zgerc) \
     XX(cblas_zgeru) \
@@ -2720,6 +2801,7 @@
     XX(cblas_zhpr2) \
     XX(cblas_zimatcopy) \
     XX(cblas_zomatcopy) \
+    XX(cblas_zrotg) \
     XX(cblas_zscal) \
     XX(cblas_zswap) \
     XX(cblas_zsymm) \
@@ -2736,1090 +2818,134 @@
     XX(ccopy_) \
     XX(cdotc_) \
     XX(cdotu_) \
-    XX(cgbbrd_) \
-    XX(cgbcon_) \
-    XX(cgbequ_) \
-    XX(cgbequb_) \
     XX(cgbmv_) \
-    XX(cgbrfs_) \
-    XX(cgbsv_) \
-    XX(cgbsvx_) \
-    XX(cgbtf2_) \
-    XX(cgbtrf_) \
-    XX(cgbtrs_) \
     XX(cgeadd_) \
-    XX(cgebak_) \
-    XX(cgebal_) \
-    XX(cgebd2_) \
-    XX(cgebrd_) \
-    XX(cgecon_) \
-    XX(cgeequ_) \
-    XX(cgeequb_) \
-    XX(cgees_) \
-    XX(cgeesx_) \
-    XX(cgeev_) \
-    XX(cgeevx_) \
-    XX(cgehd2_) \
-    XX(cgehrd_) \
-    XX(cgejsv_) \
-    XX(cgelq2_) \
-    XX(cgelq_) \
-    XX(cgelqf_) \
-    XX(cgelqt3_) \
-    XX(cgelqt_) \
-    XX(cgels_) \
-    XX(cgelsd_) \
-    XX(cgelss_) \
-    XX(cgelsy_) \
-    XX(cgemlq_) \
-    XX(cgemlqt_) \
     XX(cgemm3m_) \
     XX(cgemm_) \
     XX(cgemmt_) \
-    XX(cgemqr_) \
-    XX(cgemqrt_) \
     XX(cgemv_) \
-    XX(cgeql2_) \
-    XX(cgeqlf_) \
-    XX(cgeqp3_) \
-    XX(cgeqr2_) \
-    XX(cgeqr2p_) \
-    XX(cgeqr_) \
-    XX(cgeqrf_) \
-    XX(cgeqrfp_) \
-    XX(cgeqrt2_) \
-    XX(cgeqrt3_) \
-    XX(cgeqrt_) \
     XX(cgerc_) \
-    XX(cgerfs_) \
-    XX(cgerq2_) \
-    XX(cgerqf_) \
     XX(cgeru_) \
-    XX(cgesc2_) \
-    XX(cgesdd_) \
     XX(cgesv_) \
-    XX(cgesvd_) \
-    XX(cgesvdq_) \
-    XX(cgesvdx_) \
-    XX(cgesvj_) \
-    XX(cgesvx_) \
-    XX(cgetc2_) \
     XX(cgetf2_) \
-    XX(cgetrf2_) \
     XX(cgetrf_) \
-    XX(cgetri_) \
     XX(cgetrs_) \
-    XX(cgetsls_) \
-    XX(cggbak_) \
-    XX(cggbal_) \
-    XX(cgges3_) \
-    XX(cgges_) \
-    XX(cggesx_) \
-    XX(cggev3_) \
-    XX(cggev_) \
-    XX(cggevx_) \
-    XX(cggglm_) \
-    XX(cgghd3_) \
-    XX(cgghrd_) \
-    XX(cgglse_) \
-    XX(cggqrf_) \
-    XX(cggrqf_) \
-    XX(cggsvd3_) \
-    XX(cggsvp3_) \
-    XX(cgsvj0_) \
-    XX(cgsvj1_) \
-    XX(cgtcon_) \
-    XX(cgtrfs_) \
-    XX(cgtsv_) \
-    XX(cgtsvx_) \
-    XX(cgttrf_) \
-    XX(cgttrs_) \
-    XX(cgtts2_) \
-    XX(chb2st_kernels_) \
-    XX(chbev_) \
-    XX(chbev_2stage_) \
-    XX(chbevd_) \
-    XX(chbevd_2stage_) \
-    XX(chbevx_) \
-    XX(chbevx_2stage_) \
-    XX(chbgst_) \
-    XX(chbgv_) \
-    XX(chbgvd_) \
-    XX(chbgvx_) \
     XX(chbmv_) \
-    XX(chbtrd_) \
-    XX(checon_) \
-    XX(checon_3_) \
-    XX(checon_rook_) \
-    XX(cheequb_) \
-    XX(cheev_) \
-    XX(cheev_2stage_) \
-    XX(cheevd_) \
-    XX(cheevd_2stage_) \
-    XX(cheevr_) \
-    XX(cheevr_2stage_) \
-    XX(cheevx_) \
-    XX(cheevx_2stage_) \
-    XX(chegs2_) \
-    XX(chegst_) \
-    XX(chegv_) \
-    XX(chegv_2stage_) \
-    XX(chegvd_) \
-    XX(chegvx_) \
     XX(chemm_) \
     XX(chemv_) \
     XX(cher2_) \
     XX(cher2k_) \
     XX(cher_) \
-    XX(cherfs_) \
     XX(cherk_) \
-    XX(chesv_) \
-    XX(chesv_aa_) \
-    XX(chesv_aa_2stage_) \
-    XX(chesv_rk_) \
-    XX(chesv_rook_) \
-    XX(chesvx_) \
-    XX(cheswapr_) \
-    XX(chetd2_) \
-    XX(chetf2_) \
-    XX(chetf2_rk_) \
-    XX(chetf2_rook_) \
-    XX(chetrd_) \
-    XX(chetrd_2stage_) \
-    XX(chetrd_hb2st_) \
-    XX(chetrd_he2hb_) \
-    XX(chetrf_) \
-    XX(chetrf_aa_) \
-    XX(chetrf_aa_2stage_) \
-    XX(chetrf_rk_) \
-    XX(chetrf_rook_) \
-    XX(chetri2_) \
-    XX(chetri2x_) \
-    XX(chetri_) \
-    XX(chetri_3_) \
-    XX(chetri_3x_) \
-    XX(chetri_rook_) \
-    XX(chetrs2_) \
-    XX(chetrs_) \
-    XX(chetrs_3_) \
-    XX(chetrs_aa_) \
-    XX(chetrs_aa_2stage_) \
-    XX(chetrs_rook_) \
-    XX(chfrk_) \
-    XX(chgeqz_) \
-    XX(chla_transtype_) \
-    XX(chpcon_) \
-    XX(chpev_) \
-    XX(chpevd_) \
-    XX(chpevx_) \
-    XX(chpgst_) \
-    XX(chpgv_) \
-    XX(chpgvd_) \
-    XX(chpgvx_) \
     XX(chpmv_) \
     XX(chpr2_) \
     XX(chpr_) \
-    XX(chprfs_) \
-    XX(chpsv_) \
-    XX(chpsvx_) \
-    XX(chptrd_) \
-    XX(chptrf_) \
-    XX(chptri_) \
-    XX(chptrs_) \
-    XX(chsein_) \
-    XX(chseqr_) \
     XX(cimatcopy_) \
-    XX(clabrd_) \
-    XX(clacgv_) \
-    XX(clacn2_) \
-    XX(clacon_) \
-    XX(clacp2_) \
-    XX(clacpy_) \
-    XX(clacrm_) \
-    XX(clacrt_) \
-    XX(cladiv_) \
-    XX(claed0_) \
-    XX(claed7_) \
-    XX(claed8_) \
-    XX(claein_) \
-    XX(claesy_) \
-    XX(claev2_) \
-    XX(clag2z_) \
-    XX(clagge_) \
-    XX(claghe_) \
-    XX(clags2_) \
-    XX(clagsy_) \
-    XX(clagtm_) \
-    XX(clahef_) \
-    XX(clahef_aa_) \
-    XX(clahef_rk_) \
-    XX(clahef_rook_) \
-    XX(clahilb_) \
-    XX(clahqr_) \
-    XX(clahr2_) \
-    XX(claic1_) \
-    XX(clakf2_) \
-    XX(clals0_) \
-    XX(clalsa_) \
-    XX(clalsd_) \
-    XX(clamswlq_) \
-    XX(clamtsqr_) \
-    XX(clangb_) \
-    XX(clange_) \
-    XX(clangt_) \
-    XX(clanhb_) \
-    XX(clanhe_) \
-    XX(clanhf_) \
-    XX(clanhp_) \
-    XX(clanhs_) \
-    XX(clanht_) \
-    XX(clansb_) \
-    XX(clansp_) \
-    XX(clansy_) \
-    XX(clantb_) \
-    XX(clantp_) \
-    XX(clantr_) \
-    XX(clapll_) \
-    XX(clapmr_) \
-    XX(clapmt_) \
-    XX(claqgb_) \
-    XX(claqge_) \
-    XX(claqhb_) \
-    XX(claqhe_) \
-    XX(claqhp_) \
-    XX(claqp2_) \
-    XX(claqps_) \
-    XX(claqr0_) \
-    XX(claqr1_) \
-    XX(claqr2_) \
-    XX(claqr3_) \
-    XX(claqr4_) \
-    XX(claqr5_) \
-    XX(claqsb_) \
-    XX(claqsp_) \
-    XX(claqsy_) \
-    XX(clar1v_) \
-    XX(clar2v_) \
-    XX(clarcm_) \
-    XX(clarf_) \
-    XX(clarfb_) \
-    XX(clarfg_) \
-    XX(clarfgp_) \
-    XX(clarft_) \
-    XX(clarfx_) \
-    XX(clarfy_) \
-    XX(clarge_) \
-    XX(clargv_) \
-    XX(clarnd_) \
-    XX(clarnv_) \
-    XX(claror_) \
-    XX(clarot_) \
-    XX(clarrv_) \
-    XX(clartg_) \
-    XX(clartv_) \
-    XX(clarz_) \
-    XX(clarzb_) \
-    XX(clarzt_) \
-    XX(clascl_) \
-    XX(claset_) \
-    XX(clasr_) \
-    XX(classq_) \
-    XX(claswlq_) \
     XX(claswp_) \
-    XX(clasyf_) \
-    XX(clasyf_aa_) \
-    XX(clasyf_rk_) \
-    XX(clasyf_rook_) \
-    XX(clatbs_) \
-    XX(clatdf_) \
-    XX(clatm1_) \
-    XX(clatm2_) \
-    XX(clatm3_) \
-    XX(clatm5_) \
-    XX(clatm6_) \
-    XX(clatme_) \
-    XX(clatmr_) \
-    XX(clatms_) \
-    XX(clatmt_) \
-    XX(clatps_) \
-    XX(clatrd_) \
-    XX(clatrs_) \
-    XX(clatrz_) \
-    XX(clatsqr_) \
-    XX(claunhr_col_getrfnp2_) \
-    XX(claunhr_col_getrfnp_) \
     XX(clauu2_) \
     XX(clauum_) \
     XX(comatcopy_) \
-    XX(cpbcon_) \
-    XX(cpbequ_) \
-    XX(cpbrfs_) \
-    XX(cpbstf_) \
-    XX(cpbsv_) \
-    XX(cpbsvx_) \
-    XX(cpbtf2_) \
-    XX(cpbtrf_) \
-    XX(cpbtrs_) \
-    XX(cpftrf_) \
-    XX(cpftri_) \
-    XX(cpftrs_) \
-    XX(cpocon_) \
-    XX(cpoequ_) \
-    XX(cpoequb_) \
-    XX(cporfs_) \
-    XX(cposv_) \
-    XX(cposvx_) \
     XX(cpotf2_) \
-    XX(cpotrf2_) \
     XX(cpotrf_) \
     XX(cpotri_) \
-    XX(cpotrs_) \
-    XX(cppcon_) \
-    XX(cppequ_) \
-    XX(cpprfs_) \
-    XX(cppsv_) \
-    XX(cppsvx_) \
-    XX(cpptrf_) \
-    XX(cpptri_) \
-    XX(cpptrs_) \
-    XX(cpstf2_) \
-    XX(cpstrf_) \
-    XX(cptcon_) \
-    XX(cpteqr_) \
-    XX(cptrfs_) \
-    XX(cptsv_) \
-    XX(cptsvx_) \
-    XX(cpttrf_) \
-    XX(cpttrs_) \
-    XX(cptts2_) \
-    XX(crot_) \
     XX(crotg_) \
-    XX(csbmv_) \
     XX(cscal_) \
-    XX(cspcon_) \
-    XX(cspmv_) \
-    XX(cspr2_) \
-    XX(cspr_) \
-    XX(csprfs_) \
-    XX(cspsv_) \
-    XX(cspsvx_) \
-    XX(csptrf_) \
-    XX(csptri_) \
-    XX(csptrs_) \
     XX(csrot_) \
-    XX(csrscl_) \
     XX(csscal_) \
-    XX(cstedc_) \
-    XX(cstegr_) \
-    XX(cstein_) \
-    XX(cstemr_) \
-    XX(csteqr_) \
     XX(cswap_) \
-    XX(csycon_) \
-    XX(csycon_3_) \
-    XX(csycon_rook_) \
-    XX(csyconv_) \
-    XX(csyconvf_) \
-    XX(csyconvf_rook_) \
-    XX(csyequb_) \
     XX(csymm_) \
-    XX(csymv_) \
-    XX(csyr2_) \
     XX(csyr2k_) \
-    XX(csyr_) \
-    XX(csyrfs_) \
     XX(csyrk_) \
-    XX(csysv_) \
-    XX(csysv_aa_) \
-    XX(csysv_aa_2stage_) \
-    XX(csysv_rk_) \
-    XX(csysv_rook_) \
-    XX(csysvx_) \
-    XX(csyswapr_) \
-    XX(csytf2_) \
-    XX(csytf2_rk_) \
-    XX(csytf2_rook_) \
-    XX(csytrf_) \
-    XX(csytrf_aa_) \
-    XX(csytrf_aa_2stage_) \
-    XX(csytrf_rk_) \
-    XX(csytrf_rook_) \
-    XX(csytri2_) \
-    XX(csytri2x_) \
-    XX(csytri_) \
-    XX(csytri_3_) \
-    XX(csytri_3x_) \
-    XX(csytri_rook_) \
-    XX(csytrs2_) \
-    XX(csytrs_) \
-    XX(csytrs_3_) \
-    XX(csytrs_aa_) \
-    XX(csytrs_aa_2stage_) \
-    XX(csytrs_rook_) \
-    XX(ctbcon_) \
     XX(ctbmv_) \
-    XX(ctbrfs_) \
     XX(ctbsv_) \
-    XX(ctbtrs_) \
-    XX(ctfsm_) \
-    XX(ctftri_) \
-    XX(ctfttp_) \
-    XX(ctfttr_) \
-    XX(ctgevc_) \
-    XX(ctgex2_) \
-    XX(ctgexc_) \
-    XX(ctgsen_) \
-    XX(ctgsja_) \
-    XX(ctgsna_) \
-    XX(ctgsy2_) \
-    XX(ctgsyl_) \
-    XX(ctpcon_) \
-    XX(ctplqt2_) \
-    XX(ctplqt_) \
-    XX(ctpmlqt_) \
-    XX(ctpmqrt_) \
     XX(ctpmv_) \
-    XX(ctpqrt2_) \
-    XX(ctpqrt_) \
-    XX(ctprfb_) \
-    XX(ctprfs_) \
     XX(ctpsv_) \
-    XX(ctptri_) \
-    XX(ctptrs_) \
-    XX(ctpttf_) \
-    XX(ctpttr_) \
-    XX(ctrcon_) \
-    XX(ctrevc3_) \
-    XX(ctrevc_) \
-    XX(ctrexc_) \
     XX(ctrmm_) \
     XX(ctrmv_) \
-    XX(ctrrfs_) \
-    XX(ctrsen_) \
     XX(ctrsm_) \
-    XX(ctrsna_) \
     XX(ctrsv_) \
-    XX(ctrsyl_) \
     XX(ctrti2_) \
     XX(ctrtri_) \
-    XX(ctrtrs_) \
-    XX(ctrttf_) \
-    XX(ctrttp_) \
-    XX(ctzrzf_) \
-    XX(cunbdb1_) \
-    XX(cunbdb2_) \
-    XX(cunbdb3_) \
-    XX(cunbdb4_) \
-    XX(cunbdb5_) \
-    XX(cunbdb6_) \
-    XX(cunbdb_) \
-    XX(cuncsd2by1_) \
-    XX(cuncsd_) \
-    XX(cung2l_) \
-    XX(cung2r_) \
-    XX(cungbr_) \
-    XX(cunghr_) \
-    XX(cungl2_) \
-    XX(cunglq_) \
-    XX(cungql_) \
-    XX(cungqr_) \
-    XX(cungr2_) \
-    XX(cungrq_) \
-    XX(cungtr_) \
-    XX(cungtsqr_) \
-    XX(cunhr_col_) \
-    XX(cunm22_) \
-    XX(cunm2l_) \
-    XX(cunm2r_) \
-    XX(cunmbr_) \
-    XX(cunmhr_) \
-    XX(cunml2_) \
-    XX(cunmlq_) \
-    XX(cunmql_) \
-    XX(cunmqr_) \
-    XX(cunmr2_) \
-    XX(cunmr3_) \
-    XX(cunmrq_) \
-    XX(cunmrz_) \
-    XX(cunmtr_) \
-    XX(cupgtr_) \
-    XX(cupmtr_) \
     XX(damax_) \
     XX(damin_) \
     XX(dasum_) \
     XX(daxpby_) \
     XX(daxpy_) \
-    XX(dbbcsd_) \
-    XX(dbdsdc_) \
-    XX(dbdsqr_) \
-    XX(dbdsvdx_) \
     XX(dbf16tod_) \
     XX(dcabs1_) \
-    XX(dcombssq_) \
     XX(dcopy_) \
-    XX(ddisna_) \
     XX(ddot_) \
-    XX(dgbbrd_) \
-    XX(dgbcon_) \
-    XX(dgbequ_) \
-    XX(dgbequb_) \
     XX(dgbmv_) \
-    XX(dgbrfs_) \
-    XX(dgbsv_) \
-    XX(dgbsvx_) \
-    XX(dgbtf2_) \
-    XX(dgbtrf_) \
-    XX(dgbtrs_) \
     XX(dgeadd_) \
-    XX(dgebak_) \
-    XX(dgebal_) \
-    XX(dgebd2_) \
-    XX(dgebrd_) \
-    XX(dgecon_) \
-    XX(dgeequ_) \
-    XX(dgeequb_) \
-    XX(dgees_) \
-    XX(dgeesx_) \
-    XX(dgeev_) \
-    XX(dgeevx_) \
-    XX(dgehd2_) \
-    XX(dgehrd_) \
-    XX(dgejsv_) \
-    XX(dgelq2_) \
-    XX(dgelq_) \
-    XX(dgelqf_) \
-    XX(dgelqt3_) \
-    XX(dgelqt_) \
-    XX(dgels_) \
-    XX(dgelsd_) \
-    XX(dgelss_) \
-    XX(dgelsy_) \
-    XX(dgemlq_) \
-    XX(dgemlqt_) \
     XX(dgemm_) \
     XX(dgemmt_) \
-    XX(dgemqr_) \
-    XX(dgemqrt_) \
     XX(dgemv_) \
-    XX(dgeql2_) \
-    XX(dgeqlf_) \
-    XX(dgeqp3_) \
-    XX(dgeqr2_) \
-    XX(dgeqr2p_) \
-    XX(dgeqr_) \
-    XX(dgeqrf_) \
-    XX(dgeqrfp_) \
-    XX(dgeqrt2_) \
-    XX(dgeqrt3_) \
-    XX(dgeqrt_) \
     XX(dger_) \
-    XX(dgerfs_) \
-    XX(dgerq2_) \
-    XX(dgerqf_) \
-    XX(dgesc2_) \
-    XX(dgesdd_) \
     XX(dgesv_) \
-    XX(dgesvd_) \
-    XX(dgesvdq_) \
-    XX(dgesvdx_) \
-    XX(dgesvj_) \
-    XX(dgesvx_) \
-    XX(dgetc2_) \
     XX(dgetf2_) \
-    XX(dgetrf2_) \
     XX(dgetrf_) \
-    XX(dgetri_) \
     XX(dgetrs_) \
-    XX(dgetsls_) \
-    XX(dggbak_) \
-    XX(dggbal_) \
-    XX(dgges3_) \
-    XX(dgges_) \
-    XX(dggesx_) \
-    XX(dggev3_) \
-    XX(dggev_) \
-    XX(dggevx_) \
-    XX(dggglm_) \
-    XX(dgghd3_) \
-    XX(dgghrd_) \
-    XX(dgglse_) \
-    XX(dggqrf_) \
-    XX(dggrqf_) \
-    XX(dggsvd3_) \
-    XX(dggsvp3_) \
-    XX(dgsvj0_) \
-    XX(dgsvj1_) \
-    XX(dgtcon_) \
-    XX(dgtrfs_) \
-    XX(dgtsv_) \
-    XX(dgtsvx_) \
-    XX(dgttrf_) \
-    XX(dgttrs_) \
-    XX(dgtts2_) \
-    XX(dhgeqz_) \
-    XX(dhsein_) \
-    XX(dhseqr_) \
     XX(dimatcopy_) \
-    XX(disnan_) \
-    XX(dlabad_) \
-    XX(dlabrd_) \
-    XX(dlacn2_) \
-    XX(dlacon_) \
-    XX(dlacpy_) \
-    XX(dladiv1_) \
-    XX(dladiv2_) \
-    XX(dladiv_) \
-    XX(dlae2_) \
-    XX(dlaebz_) \
-    XX(dlaed0_) \
-    XX(dlaed1_) \
-    XX(dlaed2_) \
-    XX(dlaed3_) \
-    XX(dlaed4_) \
-    XX(dlaed5_) \
-    XX(dlaed6_) \
-    XX(dlaed7_) \
-    XX(dlaed8_) \
-    XX(dlaed9_) \
-    XX(dlaeda_) \
-    XX(dlaein_) \
-    XX(dlaev2_) \
-    XX(dlaexc_) \
-    XX(dlag2_) \
-    XX(dlag2s_) \
-    XX(dlagge_) \
-    XX(dlags2_) \
-    XX(dlagsy_) \
-    XX(dlagtf_) \
-    XX(dlagtm_) \
-    XX(dlagts_) \
-    XX(dlagv2_) \
-    XX(dlahilb_) \
-    XX(dlahqr_) \
-    XX(dlahr2_) \
-    XX(dlaic1_) \
-    XX(dlaisnan_) \
-    XX(dlakf2_) \
-    XX(dlaln2_) \
-    XX(dlals0_) \
-    XX(dlalsa_) \
-    XX(dlalsd_) \
-    XX(dlamc3_) \
-    XX(dlamch_) \
-    XX(dlamrg_) \
-    XX(dlamswlq_) \
-    XX(dlamtsqr_) \
-    XX(dlaneg_) \
-    XX(dlangb_) \
-    XX(dlange_) \
-    XX(dlangt_) \
-    XX(dlanhs_) \
-    XX(dlansb_) \
-    XX(dlansf_) \
-    XX(dlansp_) \
-    XX(dlanst_) \
-    XX(dlansy_) \
-    XX(dlantb_) \
-    XX(dlantp_) \
-    XX(dlantr_) \
-    XX(dlanv2_) \
-    XX(dlaorhr_col_getrfnp2_) \
-    XX(dlaorhr_col_getrfnp_) \
-    XX(dlapll_) \
-    XX(dlapmr_) \
-    XX(dlapmt_) \
-    XX(dlapy2_) \
-    XX(dlapy3_) \
-    XX(dlaqgb_) \
-    XX(dlaqge_) \
-    XX(dlaqp2_) \
-    XX(dlaqps_) \
-    XX(dlaqr0_) \
-    XX(dlaqr1_) \
-    XX(dlaqr2_) \
-    XX(dlaqr3_) \
-    XX(dlaqr4_) \
-    XX(dlaqr5_) \
-    XX(dlaqsb_) \
-    XX(dlaqsp_) \
-    XX(dlaqsy_) \
-    XX(dlaqtr_) \
-    XX(dlar1v_) \
-    XX(dlar2v_) \
-    XX(dlaran_) \
-    XX(dlarf_) \
-    XX(dlarfb_) \
-    XX(dlarfg_) \
-    XX(dlarfgp_) \
-    XX(dlarft_) \
-    XX(dlarfx_) \
-    XX(dlarfy_) \
-    XX(dlarge_) \
-    XX(dlargv_) \
-    XX(dlarnd_) \
-    XX(dlarnv_) \
-    XX(dlaror_) \
-    XX(dlarot_) \
-    XX(dlarra_) \
-    XX(dlarrb_) \
-    XX(dlarrc_) \
-    XX(dlarrd_) \
-    XX(dlarre_) \
-    XX(dlarrf_) \
-    XX(dlarrj_) \
-    XX(dlarrk_) \
-    XX(dlarrr_) \
-    XX(dlarrv_) \
-    XX(dlartg_) \
-    XX(dlartgp_) \
-    XX(dlartgs_) \
-    XX(dlartv_) \
-    XX(dlaruv_) \
-    XX(dlarz_) \
-    XX(dlarzb_) \
-    XX(dlarzt_) \
-    XX(dlas2_) \
-    XX(dlascl_) \
-    XX(dlasd0_) \
-    XX(dlasd1_) \
-    XX(dlasd2_) \
-    XX(dlasd3_) \
-    XX(dlasd4_) \
-    XX(dlasd5_) \
-    XX(dlasd6_) \
-    XX(dlasd7_) \
-    XX(dlasd8_) \
-    XX(dlasda_) \
-    XX(dlasdq_) \
-    XX(dlasdt_) \
-    XX(dlaset_) \
-    XX(dlasq1_) \
-    XX(dlasq2_) \
-    XX(dlasq3_) \
-    XX(dlasq4_) \
-    XX(dlasq5_) \
-    XX(dlasq6_) \
-    XX(dlasr_) \
-    XX(dlasrt_) \
-    XX(dlassq_) \
-    XX(dlasv2_) \
-    XX(dlaswlq_) \
     XX(dlaswp_) \
-    XX(dlasy2_) \
-    XX(dlasyf_) \
-    XX(dlasyf_aa_) \
-    XX(dlasyf_rk_) \
-    XX(dlasyf_rook_) \
-    XX(dlat2s_) \
-    XX(dlatbs_) \
-    XX(dlatdf_) \
-    XX(dlatm1_) \
-    XX(dlatm2_) \
-    XX(dlatm3_) \
-    XX(dlatm5_) \
-    XX(dlatm6_) \
-    XX(dlatm7_) \
-    XX(dlatme_) \
-    XX(dlatmr_) \
-    XX(dlatms_) \
-    XX(dlatmt_) \
-    XX(dlatps_) \
-    XX(dlatrd_) \
-    XX(dlatrs_) \
-    XX(dlatrz_) \
-    XX(dlatsqr_) \
     XX(dlauu2_) \
     XX(dlauum_) \
     XX(dmax_) \
     XX(dmin_) \
     XX(dnrm2_) \
     XX(domatcopy_) \
-    XX(dopgtr_) \
-    XX(dopmtr_) \
-    XX(dorbdb1_) \
-    XX(dorbdb2_) \
-    XX(dorbdb3_) \
-    XX(dorbdb4_) \
-    XX(dorbdb5_) \
-    XX(dorbdb6_) \
-    XX(dorbdb_) \
-    XX(dorcsd2by1_) \
-    XX(dorcsd_) \
-    XX(dorg2l_) \
-    XX(dorg2r_) \
-    XX(dorgbr_) \
-    XX(dorghr_) \
-    XX(dorgl2_) \
-    XX(dorglq_) \
-    XX(dorgql_) \
-    XX(dorgqr_) \
-    XX(dorgr2_) \
-    XX(dorgrq_) \
-    XX(dorgtr_) \
-    XX(dorgtsqr_) \
-    XX(dorhr_col_) \
-    XX(dorm22_) \
-    XX(dorm2l_) \
-    XX(dorm2r_) \
-    XX(dormbr_) \
-    XX(dormhr_) \
-    XX(dorml2_) \
-    XX(dormlq_) \
-    XX(dormql_) \
-    XX(dormqr_) \
-    XX(dormr2_) \
-    XX(dormr3_) \
-    XX(dormrq_) \
-    XX(dormrz_) \
-    XX(dormtr_) \
-    XX(dpbcon_) \
-    XX(dpbequ_) \
-    XX(dpbrfs_) \
-    XX(dpbstf_) \
-    XX(dpbsv_) \
-    XX(dpbsvx_) \
-    XX(dpbtf2_) \
-    XX(dpbtrf_) \
-    XX(dpbtrs_) \
-    XX(dpftrf_) \
-    XX(dpftri_) \
-    XX(dpftrs_) \
-    XX(dpocon_) \
-    XX(dpoequ_) \
-    XX(dpoequb_) \
-    XX(dporfs_) \
-    XX(dposv_) \
-    XX(dposvx_) \
     XX(dpotf2_) \
-    XX(dpotrf2_) \
     XX(dpotrf_) \
     XX(dpotri_) \
-    XX(dpotrs_) \
-    XX(dppcon_) \
-    XX(dppequ_) \
-    XX(dpprfs_) \
-    XX(dppsv_) \
-    XX(dppsvx_) \
-    XX(dpptrf_) \
-    XX(dpptri_) \
-    XX(dpptrs_) \
-    XX(dpstf2_) \
-    XX(dpstrf_) \
-    XX(dptcon_) \
-    XX(dpteqr_) \
-    XX(dptrfs_) \
-    XX(dptsv_) \
-    XX(dptsvx_) \
-    XX(dpttrf_) \
-    XX(dpttrs_) \
-    XX(dptts2_) \
     XX(drot_) \
     XX(drotg_) \
     XX(drotm_) \
     XX(drotmg_) \
-    XX(drscl_) \
-    XX(dsb2st_kernels_) \
-    XX(dsbev_) \
-    XX(dsbev_2stage_) \
-    XX(dsbevd_) \
-    XX(dsbevd_2stage_) \
-    XX(dsbevx_) \
-    XX(dsbevx_2stage_) \
-    XX(dsbgst_) \
-    XX(dsbgv_) \
-    XX(dsbgvd_) \
-    XX(dsbgvx_) \
     XX(dsbmv_) \
-    XX(dsbtrd_) \
     XX(dscal_) \
     XX(dsdot_) \
-    XX(dsecnd_) \
-    XX(dsfrk_) \
-    XX(dsgesv_) \
-    XX(dspcon_) \
-    XX(dspev_) \
-    XX(dspevd_) \
-    XX(dspevx_) \
-    XX(dspgst_) \
-    XX(dspgv_) \
-    XX(dspgvd_) \
-    XX(dspgvx_) \
     XX(dspmv_) \
-    XX(dsposv_) \
     XX(dspr2_) \
     XX(dspr_) \
-    XX(dsprfs_) \
-    XX(dspsv_) \
-    XX(dspsvx_) \
-    XX(dsptrd_) \
-    XX(dsptrf_) \
-    XX(dsptri_) \
-    XX(dsptrs_) \
-    XX(dstebz_) \
-    XX(dstedc_) \
-    XX(dstegr_) \
-    XX(dstein_) \
-    XX(dstemr_) \
-    XX(dsteqr_) \
-    XX(dsterf_) \
-    XX(dstev_) \
-    XX(dstevd_) \
-    XX(dstevr_) \
-    XX(dstevx_) \
     XX(dsum_) \
     XX(dswap_) \
-    XX(dsycon_) \
-    XX(dsycon_3_) \
-    XX(dsycon_rook_) \
-    XX(dsyconv_) \
-    XX(dsyconvf_) \
-    XX(dsyconvf_rook_) \
-    XX(dsyequb_) \
-    XX(dsyev_) \
-    XX(dsyev_2stage_) \
-    XX(dsyevd_) \
-    XX(dsyevd_2stage_) \
-    XX(dsyevr_) \
-    XX(dsyevr_2stage_) \
-    XX(dsyevx_) \
-    XX(dsyevx_2stage_) \
-    XX(dsygs2_) \
-    XX(dsygst_) \
-    XX(dsygv_) \
-    XX(dsygv_2stage_) \
-    XX(dsygvd_) \
-    XX(dsygvx_) \
     XX(dsymm_) \
     XX(dsymv_) \
     XX(dsyr2_) \
     XX(dsyr2k_) \
     XX(dsyr_) \
-    XX(dsyrfs_) \
     XX(dsyrk_) \
-    XX(dsysv_) \
-    XX(dsysv_aa_) \
-    XX(dsysv_aa_2stage_) \
-    XX(dsysv_rk_) \
-    XX(dsysv_rook_) \
-    XX(dsysvx_) \
-    XX(dsyswapr_) \
-    XX(dsytd2_) \
-    XX(dsytf2_) \
-    XX(dsytf2_rk_) \
-    XX(dsytf2_rook_) \
-    XX(dsytrd_) \
-    XX(dsytrd_2stage_) \
-    XX(dsytrd_sb2st_) \
-    XX(dsytrd_sy2sb_) \
-    XX(dsytrf_) \
-    XX(dsytrf_aa_) \
-    XX(dsytrf_aa_2stage_) \
-    XX(dsytrf_rk_) \
-    XX(dsytrf_rook_) \
-    XX(dsytri2_) \
-    XX(dsytri2x_) \
-    XX(dsytri_) \
-    XX(dsytri_3_) \
-    XX(dsytri_3x_) \
-    XX(dsytri_rook_) \
-    XX(dsytrs2_) \
-    XX(dsytrs_) \
-    XX(dsytrs_3_) \
-    XX(dsytrs_aa_) \
-    XX(dsytrs_aa_2stage_) \
-    XX(dsytrs_rook_) \
-    XX(dtbcon_) \
     XX(dtbmv_) \
-    XX(dtbrfs_) \
     XX(dtbsv_) \
-    XX(dtbtrs_) \
-    XX(dtfsm_) \
-    XX(dtftri_) \
-    XX(dtfttp_) \
-    XX(dtfttr_) \
-    XX(dtgevc_) \
-    XX(dtgex2_) \
-    XX(dtgexc_) \
-    XX(dtgsen_) \
-    XX(dtgsja_) \
-    XX(dtgsna_) \
-    XX(dtgsy2_) \
-    XX(dtgsyl_) \
-    XX(dtpcon_) \
-    XX(dtplqt2_) \
-    XX(dtplqt_) \
-    XX(dtpmlqt_) \
-    XX(dtpmqrt_) \
     XX(dtpmv_) \
-    XX(dtpqrt2_) \
-    XX(dtpqrt_) \
-    XX(dtprfb_) \
-    XX(dtprfs_) \
     XX(dtpsv_) \
-    XX(dtptri_) \
-    XX(dtptrs_) \
-    XX(dtpttf_) \
-    XX(dtpttr_) \
-    XX(dtrcon_) \
-    XX(dtrevc3_) \
-    XX(dtrevc_) \
-    XX(dtrexc_) \
     XX(dtrmm_) \
     XX(dtrmv_) \
-    XX(dtrrfs_) \
-    XX(dtrsen_) \
     XX(dtrsm_) \
-    XX(dtrsna_) \
     XX(dtrsv_) \
-    XX(dtrsyl_) \
     XX(dtrti2_) \
     XX(dtrtri_) \
-    XX(dtrtrs_) \
-    XX(dtrttf_) \
-    XX(dtrttp_) \
-    XX(dtzrzf_) \
     XX(dzamax_) \
     XX(dzamin_) \
     XX(dzasum_) \
     XX(dznrm2_) \
-    XX(dzsum1_) \
     XX(dzsum_) \
     XX(icamax_) \
     XX(icamin_) \
-    XX(icmax1_) \
     XX(idamax_) \
     XX(idamin_) \
     XX(idmax_) \
     XX(idmin_) \
-    XX(ieeeck_) \
-    XX(ilaclc_) \
-    XX(ilaclr_) \
-    XX(iladiag_) \
-    XX(iladlc_) \
-    XX(iladlr_) \
     XX(ilaenv2stage_) \
-    XX(ilaenv_) \
-    XX(ilaprec_) \
-    XX(ilaslc_) \
-    XX(ilaslr_) \
-    XX(ilatrans_) \
-    XX(ilauplo_) \
-    XX(ilaver_) \
-    XX(ilazlc_) \
-    XX(ilazlr_) \
     XX(iparam2stage_) \
-    XX(iparmq_) \
     XX(isamax_) \
     XX(isamin_) \
     XX(ismax_) \
     XX(ismin_) \
     XX(izamax_) \
     XX(izamin_) \
-    XX(izmax1_) \
     XX(lapack_make_complex_double) \
     XX(lapack_make_complex_float) \
     XX(lsame_) \
-    XX(lsamen_) \
     XX(qamax_) \
     XX(qamin_) \
     XX(qasum_) \
@@ -3863,11 +2989,7 @@
     XX(sasum_) \
     XX(saxpby_) \
     XX(saxpy_) \
-    XX(sbbcsd_) \
     XX(sbdot_) \
-    XX(sbdsdc_) \
-    XX(sbdsqr_) \
-    XX(sbdsvdx_) \
     XX(sbdtobf16_) \
     XX(sbf16tos_) \
     XX(sbgemm_) \
@@ -3878,533 +3000,63 @@
     XX(scamin_) \
     XX(scasum_) \
     XX(scnrm2_) \
-    XX(scombssq_) \
     XX(scopy_) \
-    XX(scsum1_) \
     XX(scsum_) \
-    XX(sdisna_) \
     XX(sdot_) \
     XX(sdsdot_) \
-    XX(second_) \
-    XX(sgbbrd_) \
-    XX(sgbcon_) \
-    XX(sgbequ_) \
-    XX(sgbequb_) \
     XX(sgbmv_) \
-    XX(sgbrfs_) \
-    XX(sgbsv_) \
-    XX(sgbsvx_) \
-    XX(sgbtf2_) \
-    XX(sgbtrf_) \
-    XX(sgbtrs_) \
     XX(sgeadd_) \
-    XX(sgebak_) \
-    XX(sgebal_) \
-    XX(sgebd2_) \
-    XX(sgebrd_) \
-    XX(sgecon_) \
-    XX(sgeequ_) \
-    XX(sgeequb_) \
-    XX(sgees_) \
-    XX(sgeesx_) \
-    XX(sgeev_) \
-    XX(sgeevx_) \
-    XX(sgehd2_) \
-    XX(sgehrd_) \
-    XX(sgejsv_) \
-    XX(sgelq2_) \
-    XX(sgelq_) \
-    XX(sgelqf_) \
-    XX(sgelqt3_) \
-    XX(sgelqt_) \
-    XX(sgels_) \
-    XX(sgelsd_) \
-    XX(sgelss_) \
-    XX(sgelsy_) \
-    XX(sgemlq_) \
-    XX(sgemlqt_) \
     XX(sgemm_) \
     XX(sgemmt_) \
-    XX(sgemqr_) \
-    XX(sgemqrt_) \
     XX(sgemv_) \
-    XX(sgeql2_) \
-    XX(sgeqlf_) \
-    XX(sgeqp3_) \
-    XX(sgeqr2_) \
-    XX(sgeqr2p_) \
-    XX(sgeqr_) \
-    XX(sgeqrf_) \
-    XX(sgeqrfp_) \
-    XX(sgeqrt2_) \
-    XX(sgeqrt3_) \
-    XX(sgeqrt_) \
     XX(sger_) \
-    XX(sgerfs_) \
-    XX(sgerq2_) \
-    XX(sgerqf_) \
-    XX(sgesc2_) \
-    XX(sgesdd_) \
     XX(sgesv_) \
-    XX(sgesvd_) \
-    XX(sgesvdq_) \
-    XX(sgesvdx_) \
-    XX(sgesvj_) \
-    XX(sgesvx_) \
-    XX(sgetc2_) \
     XX(sgetf2_) \
-    XX(sgetrf2_) \
     XX(sgetrf_) \
-    XX(sgetri_) \
     XX(sgetrs_) \
-    XX(sgetsls_) \
-    XX(sggbak_) \
-    XX(sggbal_) \
-    XX(sgges3_) \
-    XX(sgges_) \
-    XX(sggesx_) \
-    XX(sggev3_) \
-    XX(sggev_) \
-    XX(sggevx_) \
-    XX(sggglm_) \
-    XX(sgghd3_) \
-    XX(sgghrd_) \
-    XX(sgglse_) \
-    XX(sggqrf_) \
-    XX(sggrqf_) \
-    XX(sggsvd3_) \
-    XX(sggsvp3_) \
-    XX(sgsvj0_) \
-    XX(sgsvj1_) \
-    XX(sgtcon_) \
-    XX(sgtrfs_) \
-    XX(sgtsv_) \
-    XX(sgtsvx_) \
-    XX(sgttrf_) \
-    XX(sgttrs_) \
-    XX(sgtts2_) \
-    XX(shgeqz_) \
-    XX(shsein_) \
-    XX(shseqr_) \
     XX(simatcopy_) \
-    XX(sisnan_) \
-    XX(slabad_) \
-    XX(slabrd_) \
-    XX(slacn2_) \
-    XX(slacon_) \
-    XX(slacpy_) \
-    XX(sladiv1_) \
-    XX(sladiv2_) \
-    XX(sladiv_) \
-    XX(slae2_) \
-    XX(slaebz_) \
-    XX(slaed0_) \
-    XX(slaed1_) \
-    XX(slaed2_) \
-    XX(slaed3_) \
-    XX(slaed4_) \
-    XX(slaed5_) \
-    XX(slaed6_) \
-    XX(slaed7_) \
-    XX(slaed8_) \
-    XX(slaed9_) \
-    XX(slaeda_) \
-    XX(slaein_) \
-    XX(slaev2_) \
-    XX(slaexc_) \
-    XX(slag2_) \
-    XX(slag2d_) \
-    XX(slagge_) \
-    XX(slags2_) \
-    XX(slagsy_) \
-    XX(slagtf_) \
-    XX(slagtm_) \
-    XX(slagts_) \
-    XX(slagv2_) \
-    XX(slahilb_) \
-    XX(slahqr_) \
-    XX(slahr2_) \
-    XX(slaic1_) \
-    XX(slaisnan_) \
-    XX(slakf2_) \
-    XX(slaln2_) \
-    XX(slals0_) \
-    XX(slalsa_) \
-    XX(slalsd_) \
-    XX(slamc3_) \
-    XX(slamch_) \
-    XX(slamrg_) \
-    XX(slamswlq_) \
-    XX(slamtsqr_) \
-    XX(slaneg_) \
-    XX(slangb_) \
-    XX(slange_) \
-    XX(slangt_) \
-    XX(slanhs_) \
-    XX(slansb_) \
-    XX(slansf_) \
-    XX(slansp_) \
-    XX(slanst_) \
-    XX(slansy_) \
-    XX(slantb_) \
-    XX(slantp_) \
-    XX(slantr_) \
-    XX(slanv2_) \
-    XX(slaorhr_col_getrfnp2_) \
-    XX(slaorhr_col_getrfnp_) \
-    XX(slapll_) \
-    XX(slapmr_) \
-    XX(slapmt_) \
-    XX(slapy2_) \
-    XX(slapy3_) \
-    XX(slaqgb_) \
-    XX(slaqge_) \
-    XX(slaqp2_) \
-    XX(slaqps_) \
-    XX(slaqr0_) \
-    XX(slaqr1_) \
-    XX(slaqr2_) \
-    XX(slaqr3_) \
-    XX(slaqr4_) \
-    XX(slaqr5_) \
-    XX(slaqsb_) \
-    XX(slaqsp_) \
-    XX(slaqsy_) \
-    XX(slaqtr_) \
-    XX(slar1v_) \
-    XX(slar2v_) \
-    XX(slaran_) \
-    XX(slarf_) \
-    XX(slarfb_) \
-    XX(slarfg_) \
-    XX(slarfgp_) \
-    XX(slarft_) \
-    XX(slarfx_) \
-    XX(slarfy_) \
-    XX(slarge_) \
-    XX(slargv_) \
-    XX(slarnd_) \
-    XX(slarnv_) \
-    XX(slaror_) \
-    XX(slarot_) \
-    XX(slarra_) \
-    XX(slarrb_) \
-    XX(slarrc_) \
-    XX(slarrd_) \
-    XX(slarre_) \
-    XX(slarrf_) \
-    XX(slarrj_) \
-    XX(slarrk_) \
-    XX(slarrr_) \
-    XX(slarrv_) \
-    XX(slartg_) \
-    XX(slartgp_) \
-    XX(slartgs_) \
-    XX(slartv_) \
-    XX(slaruv_) \
-    XX(slarz_) \
-    XX(slarzb_) \
-    XX(slarzt_) \
-    XX(slas2_) \
-    XX(slascl_) \
-    XX(slasd0_) \
-    XX(slasd1_) \
-    XX(slasd2_) \
-    XX(slasd3_) \
-    XX(slasd4_) \
-    XX(slasd5_) \
-    XX(slasd6_) \
-    XX(slasd7_) \
-    XX(slasd8_) \
-    XX(slasda_) \
-    XX(slasdq_) \
-    XX(slasdt_) \
-    XX(slaset_) \
-    XX(slasq1_) \
-    XX(slasq2_) \
-    XX(slasq3_) \
-    XX(slasq4_) \
-    XX(slasq5_) \
-    XX(slasq6_) \
-    XX(slasr_) \
-    XX(slasrt_) \
-    XX(slassq_) \
-    XX(slasv2_) \
-    XX(slaswlq_) \
     XX(slaswp_) \
-    XX(slasy2_) \
-    XX(slasyf_) \
-    XX(slasyf_aa_) \
-    XX(slasyf_rk_) \
-    XX(slasyf_rook_) \
-    XX(slatbs_) \
-    XX(slatdf_) \
-    XX(slatm1_) \
-    XX(slatm2_) \
-    XX(slatm3_) \
-    XX(slatm5_) \
-    XX(slatm6_) \
-    XX(slatm7_) \
-    XX(slatme_) \
-    XX(slatmr_) \
-    XX(slatms_) \
-    XX(slatmt_) \
-    XX(slatps_) \
-    XX(slatrd_) \
-    XX(slatrs_) \
-    XX(slatrz_) \
-    XX(slatsqr_) \
     XX(slauu2_) \
     XX(slauum_) \
     XX(smax_) \
     XX(smin_) \
     XX(snrm2_) \
     XX(somatcopy_) \
-    XX(sopgtr_) \
-    XX(sopmtr_) \
-    XX(sorbdb1_) \
-    XX(sorbdb2_) \
-    XX(sorbdb3_) \
-    XX(sorbdb4_) \
-    XX(sorbdb5_) \
-    XX(sorbdb6_) \
-    XX(sorbdb_) \
-    XX(sorcsd2by1_) \
-    XX(sorcsd_) \
-    XX(sorg2l_) \
-    XX(sorg2r_) \
-    XX(sorgbr_) \
-    XX(sorghr_) \
-    XX(sorgl2_) \
-    XX(sorglq_) \
-    XX(sorgql_) \
-    XX(sorgqr_) \
-    XX(sorgr2_) \
-    XX(sorgrq_) \
-    XX(sorgtr_) \
-    XX(sorgtsqr_) \
-    XX(sorhr_col_) \
-    XX(sorm22_) \
-    XX(sorm2l_) \
-    XX(sorm2r_) \
-    XX(sormbr_) \
-    XX(sormhr_) \
-    XX(sorml2_) \
-    XX(sormlq_) \
-    XX(sormql_) \
-    XX(sormqr_) \
-    XX(sormr2_) \
-    XX(sormr3_) \
-    XX(sormrq_) \
-    XX(sormrz_) \
-    XX(sormtr_) \
-    XX(spbcon_) \
-    XX(spbequ_) \
-    XX(spbrfs_) \
-    XX(spbstf_) \
-    XX(spbsv_) \
-    XX(spbsvx_) \
-    XX(spbtf2_) \
-    XX(spbtrf_) \
-    XX(spbtrs_) \
-    XX(spftrf_) \
-    XX(spftri_) \
-    XX(spftrs_) \
-    XX(spocon_) \
-    XX(spoequ_) \
-    XX(spoequb_) \
-    XX(sporfs_) \
-    XX(sposv_) \
-    XX(sposvx_) \
     XX(spotf2_) \
-    XX(spotrf2_) \
     XX(spotrf_) \
     XX(spotri_) \
-    XX(spotrs_) \
-    XX(sppcon_) \
-    XX(sppequ_) \
-    XX(spprfs_) \
-    XX(sppsv_) \
-    XX(sppsvx_) \
-    XX(spptrf_) \
-    XX(spptri_) \
-    XX(spptrs_) \
-    XX(spstf2_) \
-    XX(spstrf_) \
-    XX(sptcon_) \
-    XX(spteqr_) \
-    XX(sptrfs_) \
-    XX(sptsv_) \
-    XX(sptsvx_) \
-    XX(spttrf_) \
-    XX(spttrs_) \
-    XX(sptts2_) \
     XX(srot_) \
     XX(srotg_) \
     XX(srotm_) \
     XX(srotmg_) \
-    XX(srscl_) \
-    XX(ssb2st_kernels_) \
-    XX(ssbev_) \
-    XX(ssbev_2stage_) \
-    XX(ssbevd_) \
-    XX(ssbevd_2stage_) \
-    XX(ssbevx_) \
-    XX(ssbevx_2stage_) \
-    XX(ssbgst_) \
-    XX(ssbgv_) \
-    XX(ssbgvd_) \
-    XX(ssbgvx_) \
     XX(ssbmv_) \
-    XX(ssbtrd_) \
     XX(sscal_) \
-    XX(ssfrk_) \
-    XX(sspcon_) \
-    XX(sspev_) \
-    XX(sspevd_) \
-    XX(sspevx_) \
-    XX(sspgst_) \
-    XX(sspgv_) \
-    XX(sspgvd_) \
-    XX(sspgvx_) \
     XX(sspmv_) \
     XX(sspr2_) \
     XX(sspr_) \
-    XX(ssprfs_) \
-    XX(sspsv_) \
-    XX(sspsvx_) \
-    XX(ssptrd_) \
-    XX(ssptrf_) \
-    XX(ssptri_) \
-    XX(ssptrs_) \
-    XX(sstebz_) \
-    XX(sstedc_) \
-    XX(sstegr_) \
-    XX(sstein_) \
-    XX(sstemr_) \
-    XX(ssteqr_) \
-    XX(ssterf_) \
-    XX(sstev_) \
-    XX(sstevd_) \
-    XX(sstevr_) \
-    XX(sstevx_) \
     XX(ssum_) \
     XX(sswap_) \
-    XX(ssycon_) \
-    XX(ssycon_3_) \
-    XX(ssycon_rook_) \
-    XX(ssyconv_) \
-    XX(ssyconvf_rook_) \
-    XX(ssyequb_) \
-    XX(ssyev_) \
-    XX(ssyev_2stage_) \
-    XX(ssyevd_) \
-    XX(ssyevd_2stage_) \
-    XX(ssyevr_) \
-    XX(ssyevr_2stage_) \
-    XX(ssyevx_) \
-    XX(ssyevx_2stage_) \
-    XX(ssygs2_) \
-    XX(ssygst_) \
-    XX(ssygv_) \
-    XX(ssygv_2stage_) \
-    XX(ssygvd_) \
-    XX(ssygvx_) \
     XX(ssymm_) \
     XX(ssymv_) \
     XX(ssyr2_) \
     XX(ssyr2k_) \
     XX(ssyr_) \
-    XX(ssyrfs_) \
     XX(ssyrk_) \
-    XX(ssysv_) \
-    XX(ssysv_aa_) \
-    XX(ssysv_aa_2stage_) \
-    XX(ssysv_rk_) \
-    XX(ssysv_rook_) \
-    XX(ssysvx_) \
-    XX(ssyswapr_) \
-    XX(ssytd2_) \
-    XX(ssytf2_) \
-    XX(ssytf2_rk_) \
-    XX(ssytf2_rook_) \
-    XX(ssytrd_) \
-    XX(ssytrd_2stage_) \
-    XX(ssytrd_sb2st_) \
-    XX(ssytrd_sy2sb_) \
-    XX(ssytrf_) \
-    XX(ssytrf_aa_) \
-    XX(ssytrf_aa_2stage_) \
-    XX(ssytrf_rk_) \
-    XX(ssytrf_rook_) \
-    XX(ssytri2_) \
-    XX(ssytri2x_) \
-    XX(ssytri_) \
-    XX(ssytri_3_) \
-    XX(ssytri_3x_) \
-    XX(ssytri_rook_) \
-    XX(ssytrs2_) \
-    XX(ssytrs_) \
-    XX(ssytrs_3_) \
-    XX(ssytrs_aa_) \
-    XX(ssytrs_aa_2stage_) \
-    XX(ssytrs_rook_) \
-    XX(stbcon_) \
     XX(stbmv_) \
-    XX(stbrfs_) \
     XX(stbsv_) \
-    XX(stbtrs_) \
-    XX(stfsm_) \
-    XX(stftri_) \
-    XX(stfttp_) \
-    XX(stfttr_) \
-    XX(stgevc_) \
-    XX(stgex2_) \
-    XX(stgexc_) \
-    XX(stgsen_) \
-    XX(stgsja_) \
-    XX(stgsna_) \
-    XX(stgsy2_) \
-    XX(stgsyl_) \
-    XX(stpcon_) \
-    XX(stplqt2_) \
-    XX(stplqt_) \
-    XX(stpmlqt_) \
-    XX(stpmqrt_) \
     XX(stpmv_) \
-    XX(stpqrt2_) \
-    XX(stpqrt_) \
-    XX(stprfb_) \
-    XX(stprfs_) \
     XX(stpsv_) \
-    XX(stptri_) \
-    XX(stptrs_) \
-    XX(stpttf_) \
-    XX(stpttr_) \
-    XX(strcon_) \
-    XX(strevc3_) \
-    XX(strevc_) \
-    XX(strexc_) \
     XX(strmm_) \
     XX(strmv_) \
-    XX(strrfs_) \
-    XX(strsen_) \
     XX(strsm_) \
-    XX(strsna_) \
     XX(strsv_) \
-    XX(strsyl_) \
     XX(strti2_) \
     XX(strtri_) \
-    XX(strtrs_) \
-    XX(strttf_) \
-    XX(strttp_) \
-    XX(stzrzf_) \
     XX(xaxpy_) \
     XX(xcopy_) \
     XX(xdotc_) \
     XX(xdotu_) \
     XX(xerbla_) \
-    XX(xerbla_array_) \
     XX(xgbmv_) \
     XX(xgemm_) \
     XX(xgemv_) \
@@ -4436,567 +3088,101 @@
     XX(xtrsv_) \
     XX(zaxpby_) \
     XX(zaxpy_) \
-    XX(zbbcsd_) \
-    XX(zbdsqr_) \
-    XX(zcgesv_) \
     XX(zcopy_) \
-    XX(zcposv_) \
     XX(zdotc_) \
     XX(zdotu_) \
     XX(zdrot_) \
-    XX(zdrscl_) \
     XX(zdscal_) \
-    XX(zgbbrd_) \
-    XX(zgbcon_) \
-    XX(zgbequ_) \
-    XX(zgbequb_) \
     XX(zgbmv_) \
-    XX(zgbrfs_) \
-    XX(zgbsv_) \
-    XX(zgbsvx_) \
-    XX(zgbtf2_) \
-    XX(zgbtrf_) \
-    XX(zgbtrs_) \
     XX(zgeadd_) \
-    XX(zgebak_) \
-    XX(zgebal_) \
-    XX(zgebd2_) \
-    XX(zgebrd_) \
-    XX(zgecon_) \
-    XX(zgeequ_) \
-    XX(zgeequb_) \
-    XX(zgees_) \
-    XX(zgeesx_) \
-    XX(zgeev_) \
-    XX(zgeevx_) \
-    XX(zgehd2_) \
-    XX(zgehrd_) \
-    XX(zgejsv_) \
-    XX(zgelq2_) \
-    XX(zgelq_) \
-    XX(zgelqf_) \
-    XX(zgelqt3_) \
-    XX(zgelqt_) \
-    XX(zgels_) \
-    XX(zgelsd_) \
-    XX(zgelss_) \
-    XX(zgelsy_) \
-    XX(zgemlq_) \
-    XX(zgemlqt_) \
     XX(zgemm3m_) \
     XX(zgemm_) \
     XX(zgemmt_) \
-    XX(zgemqr_) \
-    XX(zgemqrt_) \
     XX(zgemv_) \
-    XX(zgeql2_) \
-    XX(zgeqlf_) \
-    XX(zgeqp3_) \
-    XX(zgeqr2_) \
-    XX(zgeqr2p_) \
-    XX(zgeqr_) \
-    XX(zgeqrf_) \
-    XX(zgeqrfp_) \
-    XX(zgeqrt2_) \
-    XX(zgeqrt3_) \
-    XX(zgeqrt_) \
     XX(zgerc_) \
-    XX(zgerfs_) \
-    XX(zgerq2_) \
-    XX(zgerqf_) \
     XX(zgeru_) \
-    XX(zgesc2_) \
-    XX(zgesdd_) \
     XX(zgesv_) \
-    XX(zgesvd_) \
-    XX(zgesvdq_) \
-    XX(zgesvdx_) \
-    XX(zgesvj_) \
-    XX(zgesvx_) \
-    XX(zgetc2_) \
     XX(zgetf2_) \
-    XX(zgetrf2_) \
     XX(zgetrf_) \
-    XX(zgetri_) \
     XX(zgetrs_) \
-    XX(zgetsls_) \
-    XX(zggbak_) \
-    XX(zggbal_) \
-    XX(zgges3_) \
-    XX(zgges_) \
-    XX(zggesx_) \
-    XX(zggev3_) \
-    XX(zggev_) \
-    XX(zggevx_) \
-    XX(zggglm_) \
-    XX(zgghd3_) \
-    XX(zgghrd_) \
-    XX(zgglse_) \
-    XX(zggqrf_) \
-    XX(zggrqf_) \
-    XX(zggsvd3_) \
-    XX(zggsvp3_) \
-    XX(zgsvj0_) \
-    XX(zgsvj1_) \
-    XX(zgtcon_) \
-    XX(zgtrfs_) \
-    XX(zgtsv_) \
-    XX(zgtsvx_) \
-    XX(zgttrf_) \
-    XX(zgttrs_) \
-    XX(zgtts2_) \
-    XX(zhb2st_kernels_) \
-    XX(zhbev_) \
-    XX(zhbev_2stage_) \
-    XX(zhbevd_) \
-    XX(zhbevd_2stage_) \
-    XX(zhbevx_) \
-    XX(zhbevx_2stage_) \
-    XX(zhbgst_) \
-    XX(zhbgv_) \
-    XX(zhbgvd_) \
-    XX(zhbgvx_) \
     XX(zhbmv_) \
-    XX(zhbtrd_) \
-    XX(zhecon_) \
-    XX(zhecon_3_) \
-    XX(zhecon_rook_) \
-    XX(zheequb_) \
-    XX(zheev_) \
-    XX(zheev_2stage_) \
-    XX(zheevd_) \
-    XX(zheevd_2stage_) \
-    XX(zheevr_) \
-    XX(zheevr_2stage_) \
-    XX(zheevx_) \
-    XX(zheevx_2stage_) \
-    XX(zhegs2_) \
-    XX(zhegst_) \
-    XX(zhegv_) \
-    XX(zhegv_2stage_) \
-    XX(zhegvd_) \
-    XX(zhegvx_) \
     XX(zhemm_) \
     XX(zhemv_) \
     XX(zher2_) \
     XX(zher2k_) \
     XX(zher_) \
-    XX(zherfs_) \
     XX(zherk_) \
-    XX(zhesv_) \
-    XX(zhesv_aa_) \
-    XX(zhesv_aa_2stage_) \
-    XX(zhesv_rk_) \
-    XX(zhesv_rook_) \
-    XX(zhesvx_) \
-    XX(zheswapr_) \
-    XX(zhetd2_) \
-    XX(zhetf2_) \
-    XX(zhetf2_rk_) \
-    XX(zhetf2_rook_) \
-    XX(zhetrd_) \
-    XX(zhetrd_2stage_) \
-    XX(zhetrd_hb2st_) \
-    XX(zhetrd_he2hb_) \
-    XX(zhetrf_) \
-    XX(zhetrf_aa_) \
-    XX(zhetrf_aa_2stage_) \
-    XX(zhetrf_rk_) \
-    XX(zhetrf_rook_) \
-    XX(zhetri2_) \
-    XX(zhetri2x_) \
-    XX(zhetri_) \
-    XX(zhetri_3_) \
-    XX(zhetri_3x_) \
-    XX(zhetri_rook_) \
-    XX(zhetrs2_) \
-    XX(zhetrs_) \
-    XX(zhetrs_3_) \
-    XX(zhetrs_aa_) \
-    XX(zhetrs_aa_2stage_) \
-    XX(zhetrs_rook_) \
-    XX(zhfrk_) \
-    XX(zhgeqz_) \
-    XX(zhpcon_) \
-    XX(zhpev_) \
-    XX(zhpevd_) \
-    XX(zhpevx_) \
-    XX(zhpgst_) \
-    XX(zhpgv_) \
-    XX(zhpgvd_) \
-    XX(zhpgvx_) \
     XX(zhpmv_) \
     XX(zhpr2_) \
     XX(zhpr_) \
-    XX(zhprfs_) \
-    XX(zhpsv_) \
-    XX(zhpsvx_) \
-    XX(zhptrd_) \
-    XX(zhptrf_) \
-    XX(zhptri_) \
-    XX(zhptrs_) \
-    XX(zhsein_) \
-    XX(zhseqr_) \
     XX(zimatcopy_) \
-    XX(zlabrd_) \
-    XX(zlacgv_) \
-    XX(zlacn2_) \
-    XX(zlacon_) \
-    XX(zlacp2_) \
-    XX(zlacpy_) \
-    XX(zlacrm_) \
-    XX(zlacrt_) \
-    XX(zladiv_) \
-    XX(zlaed0_) \
-    XX(zlaed7_) \
-    XX(zlaed8_) \
-    XX(zlaein_) \
-    XX(zlaesy_) \
-    XX(zlaev2_) \
-    XX(zlag2c_) \
-    XX(zlagge_) \
-    XX(zlaghe_) \
-    XX(zlags2_) \
-    XX(zlagsy_) \
-    XX(zlagtm_) \
-    XX(zlahef_) \
-    XX(zlahef_aa_) \
-    XX(zlahef_rk_) \
-    XX(zlahef_rook_) \
-    XX(zlahilb_) \
-    XX(zlahqr_) \
-    XX(zlahr2_) \
-    XX(zlaic1_) \
-    XX(zlakf2_) \
-    XX(zlals0_) \
-    XX(zlalsa_) \
-    XX(zlalsd_) \
-    XX(zlamswlq_) \
-    XX(zlamtsqr_) \
-    XX(zlangb_) \
-    XX(zlange_) \
-    XX(zlangt_) \
-    XX(zlanhb_) \
-    XX(zlanhe_) \
-    XX(zlanhf_) \
-    XX(zlanhp_) \
-    XX(zlanhs_) \
-    XX(zlanht_) \
-    XX(zlansb_) \
-    XX(zlansp_) \
-    XX(zlansy_) \
-    XX(zlantb_) \
-    XX(zlantp_) \
-    XX(zlantr_) \
-    XX(zlapll_) \
-    XX(zlapmr_) \
-    XX(zlapmt_) \
-    XX(zlaqgb_) \
-    XX(zlaqge_) \
-    XX(zlaqhb_) \
-    XX(zlaqhe_) \
-    XX(zlaqhp_) \
-    XX(zlaqp2_) \
-    XX(zlaqps_) \
-    XX(zlaqr0_) \
-    XX(zlaqr1_) \
-    XX(zlaqr2_) \
-    XX(zlaqr3_) \
-    XX(zlaqr4_) \
-    XX(zlaqr5_) \
-    XX(zlaqsb_) \
-    XX(zlaqsp_) \
-    XX(zlaqsy_) \
-    XX(zlar1v_) \
-    XX(zlar2v_) \
-    XX(zlarcm_) \
-    XX(zlarf_) \
-    XX(zlarfb_) \
-    XX(zlarfg_) \
-    XX(zlarfgp_) \
-    XX(zlarft_) \
-    XX(zlarfx_) \
-    XX(zlarfy_) \
-    XX(zlarge_) \
-    XX(zlargv_) \
-    XX(zlarnd_) \
-    XX(zlarnv_) \
-    XX(zlaror_) \
-    XX(zlarot_) \
-    XX(zlarrv_) \
-    XX(zlartg_) \
-    XX(zlartv_) \
-    XX(zlarz_) \
-    XX(zlarzb_) \
-    XX(zlarzt_) \
-    XX(zlascl_) \
-    XX(zlaset_) \
-    XX(zlasr_) \
-    XX(zlassq_) \
-    XX(zlaswlq_) \
     XX(zlaswp_) \
-    XX(zlasyf_) \
-    XX(zlasyf_aa_) \
-    XX(zlasyf_rk_) \
-    XX(zlasyf_rook_) \
-    XX(zlat2c_) \
-    XX(zlatbs_) \
-    XX(zlatdf_) \
-    XX(zlatm1_) \
-    XX(zlatm2_) \
-    XX(zlatm3_) \
-    XX(zlatm5_) \
-    XX(zlatm6_) \
-    XX(zlatme_) \
-    XX(zlatmr_) \
-    XX(zlatms_) \
-    XX(zlatmt_) \
-    XX(zlatps_) \
-    XX(zlatrd_) \
-    XX(zlatrs_) \
-    XX(zlatrz_) \
-    XX(zlatsqr_) \
-    XX(zlaunhr_col_getrfnp2_) \
-    XX(zlaunhr_col_getrfnp_) \
     XX(zlauu2_) \
     XX(zlauum_) \
     XX(zomatcopy_) \
-    XX(zpbcon_) \
-    XX(zpbequ_) \
-    XX(zpbrfs_) \
-    XX(zpbstf_) \
-    XX(zpbsv_) \
-    XX(zpbsvx_) \
-    XX(zpbtf2_) \
-    XX(zpbtrf_) \
-    XX(zpbtrs_) \
-    XX(zpftrf_) \
-    XX(zpftri_) \
-    XX(zpftrs_) \
-    XX(zpocon_) \
-    XX(zpoequ_) \
-    XX(zpoequb_) \
-    XX(zporfs_) \
-    XX(zposv_) \
-    XX(zposvx_) \
     XX(zpotf2_) \
-    XX(zpotrf2_) \
     XX(zpotrf_) \
     XX(zpotri_) \
-    XX(zpotrs_) \
-    XX(zppcon_) \
-    XX(zppequ_) \
-    XX(zpprfs_) \
-    XX(zppsv_) \
-    XX(zppsvx_) \
-    XX(zpptrf_) \
-    XX(zpptri_) \
-    XX(zpptrs_) \
-    XX(zpstf2_) \
-    XX(zpstrf_) \
-    XX(zptcon_) \
-    XX(zpteqr_) \
-    XX(zptrfs_) \
-    XX(zptsv_) \
-    XX(zptsvx_) \
-    XX(zpttrf_) \
-    XX(zpttrs_) \
-    XX(zptts2_) \
-    XX(zrot_) \
     XX(zrotg_) \
-    XX(zsbmv_) \
     XX(zscal_) \
-    XX(zspcon_) \
-    XX(zspmv_) \
-    XX(zspr2_) \
-    XX(zspr_) \
-    XX(zsprfs_) \
-    XX(zspsv_) \
-    XX(zspsvx_) \
-    XX(zsptrf_) \
-    XX(zsptri_) \
-    XX(zsptrs_) \
-    XX(zstedc_) \
-    XX(zstegr_) \
-    XX(zstein_) \
-    XX(zstemr_) \
-    XX(zsteqr_) \
     XX(zswap_) \
-    XX(zsycon_) \
-    XX(zsycon_3_) \
-    XX(zsycon_rook_) \
-    XX(zsyconv_) \
-    XX(zsyconvf_) \
-    XX(zsyconvf_rook_) \
-    XX(zsyequb_) \
     XX(zsymm_) \
-    XX(zsymv_) \
-    XX(zsyr2_) \
     XX(zsyr2k_) \
-    XX(zsyr_) \
-    XX(zsyrfs_) \
     XX(zsyrk_) \
-    XX(zsysv_) \
-    XX(zsysv_aa_) \
-    XX(zsysv_aa_2stage_) \
-    XX(zsysv_rk_) \
-    XX(zsysv_rook_) \
-    XX(zsysvx_) \
-    XX(zsyswapr_) \
-    XX(zsytf2_) \
-    XX(zsytf2_rk_) \
-    XX(zsytf2_rook_) \
-    XX(zsytrf_) \
-    XX(zsytrf_aa_) \
-    XX(zsytrf_aa_2stage_) \
-    XX(zsytrf_rk_) \
-    XX(zsytrf_rook_) \
-    XX(zsytri2_) \
-    XX(zsytri2x_) \
-    XX(zsytri_) \
-    XX(zsytri_3_) \
-    XX(zsytri_3x_) \
-    XX(zsytri_rook_) \
-    XX(zsytrs2_) \
-    XX(zsytrs_) \
-    XX(zsytrs_3_) \
-    XX(zsytrs_aa_) \
-    XX(zsytrs_aa_2stage_) \
-    XX(zsytrs_rook_) \
-    XX(ztbcon_) \
     XX(ztbmv_) \
-    XX(ztbrfs_) \
     XX(ztbsv_) \
-    XX(ztbtrs_) \
-    XX(ztfsm_) \
-    XX(ztftri_) \
-    XX(ztfttp_) \
-    XX(ztfttr_) \
-    XX(ztgevc_) \
-    XX(ztgex2_) \
-    XX(ztgexc_) \
-    XX(ztgsen_) \
-    XX(ztgsja_) \
-    XX(ztgsna_) \
-    XX(ztgsy2_) \
-    XX(ztgsyl_) \
-    XX(ztpcon_) \
-    XX(ztplqt2_) \
-    XX(ztplqt_) \
-    XX(ztpmlqt_) \
-    XX(ztpmqrt_) \
     XX(ztpmv_) \
-    XX(ztpqrt2_) \
-    XX(ztpqrt_) \
-    XX(ztprfb_) \
-    XX(ztprfs_) \
     XX(ztpsv_) \
-    XX(ztptri_) \
-    XX(ztptrs_) \
-    XX(ztpttf_) \
-    XX(ztpttr_) \
-    XX(ztrcon_) \
-    XX(ztrevc3_) \
-    XX(ztrevc_) \
-    XX(ztrexc_) \
     XX(ztrmm_) \
     XX(ztrmv_) \
-    XX(ztrrfs_) \
-    XX(ztrsen_) \
     XX(ztrsm_) \
-    XX(ztrsna_) \
     XX(ztrsv_) \
-    XX(ztrsyl_) \
     XX(ztrti2_) \
     XX(ztrtri_) \
-    XX(ztrtrs_) \
-    XX(ztrttf_) \
-    XX(ztrttp_) \
-    XX(ztzrzf_) \
-    XX(zunbdb1_) \
-    XX(zunbdb2_) \
-    XX(zunbdb3_) \
-    XX(zunbdb4_) \
-    XX(zunbdb5_) \
-    XX(zunbdb6_) \
-    XX(zunbdb_) \
-    XX(zuncsd2by1_) \
-    XX(zuncsd_) \
-    XX(zung2l_) \
-    XX(zung2r_) \
-    XX(zungbr_) \
-    XX(zunghr_) \
-    XX(zungl2_) \
-    XX(zunglq_) \
-    XX(zungql_) \
-    XX(zungqr_) \
-    XX(zungr2_) \
-    XX(zungrq_) \
-    XX(zungtr_) \
-    XX(zungtsqr_) \
-    XX(zunhr_col_) \
-    XX(zunm22_) \
-    XX(zunm2l_) \
-    XX(zunm2r_) \
-    XX(zunmbr_) \
-    XX(zunmhr_) \
-    XX(zunml2_) \
-    XX(zunmlq_) \
-    XX(zunmql_) \
-    XX(zunmqr_) \
-    XX(zunmr2_) \
-    XX(zunmr3_) \
-    XX(zunmrq_) \
-    XX(zunmrz_) \
-    XX(zunmtr_) \
-    XX(zupgtr_) \
-    XX(zupmtr_) \
 
-#define NUM_EXPORTED_FUNCS 4949
+#define NUM_EXPORTED_FUNCS 3137
 #endif
 
 #ifndef FLOAT32_FUNCS
 #define FLOAT32_FUNCS(XX) \
-    XX(sdot_, 3881) \
-    XX(sdsdot_, 3882) \
-    XX(sasum_, 3858) \
-    XX(scasum_, 3874) \
-    XX(ssum_, 4286) \
-    XX(scsum_, 3879) \
-    XX(samax_, 3856) \
-    XX(scamax_, 3872) \
-    XX(samin_, 3857) \
-    XX(scamin_, 3873) \
-    XX(smax_, 4154) \
-    XX(smin_, 4155) \
-    XX(snrm2_, 4156) \
-    XX(scnrm2_, 3875) \
-    XX(slamch_, 4030) \
-    XX(slamc3_, 4029) \
+    XX(sdot_, 3000) \
+    XX(sdsdot_, 3001) \
+    XX(sasum_, 2984) \
+    XX(scasum_, 2996) \
+    XX(ssum_, 3032) \
+    XX(scsum_, 2999) \
+    XX(samax_, 2982) \
+    XX(scamax_, 2994) \
+    XX(samin_, 2983) \
+    XX(scamin_, 2995) \
+    XX(smax_, 3016) \
+    XX(smin_, 3017) \
+    XX(snrm2_, 3018) \
+    XX(scnrm2_, 2997) \
 
 #endif
 
 #ifndef COMPLEX64_FUNCS
 #define COMPLEX64_FUNCS(XX) \
-    XX(cdotu_, 2733) \
-    XX(cdotc_, 2732) \
+    XX(cdotu_, 2815) \
+    XX(cdotc_, 2814) \
 
 #endif
 
 #ifndef COMPLEX128_FUNCS
 #define COMPLEX128_FUNCS(XX) \
-    XX(zdotu_, 4440) \
-    XX(zdotc_, 4439) \
+    XX(zdotu_, 3088) \
+    XX(zdotc_, 3087) \
 
 #endif
 
 #ifndef CBLAS_WORKAROUND_FUNCS
 #define CBLAS_WORKAROUND_FUNCS(XX) \
-    XX(cblas_cdotc_sub, 2547) \
-    XX(cblas_cdotu_sub, 2549) \
-    XX(cblas_zdotc_sub, 2695) \
-    XX(cblas_zdotu_sub, 2697) \
-    XX(cblas_ddot, 2588) \
-    XX(cblas_sdot, 2655) \
+    XX(cblas_cdotc_sub, 2612) \
+    XX(cblas_cdotu_sub, 2614) \
+    XX(cblas_zdotc_sub, 2774) \
+    XX(cblas_zdotu_sub, 2776) \
+    XX(cblas_ddot, 2658) \
+    XX(cblas_sdot, 2732) \
 
 #endif


### PR DESCRIPTION
@staticfloat 
I modified the folder `gensymbol` because the Perl file `gensymbol.pl` is not upddated anymore in OpenBLAS.
They now rely on a shell script.

The issue is that we have less symbols in `exported_funcs.inc` now.
Maybe something else should be updated in `ext/gensymbol/generate_func_list.sh`?

close #120 