### PR TITLE
Release v5.12

### DIFF
--- a/src/Make.inc
+++ b/src/Make.inc
@@ -24,8 +24,8 @@ ifneq (,$(findstring MINGW,$(OS))$(findstring MSYS,$(OS))$(findstring CYGWIN,$(O
 endif
 
 LBT_SOVERSION_MAJOR := 5
-LBT_SOVERSION_MINOR := 11
-LBT_SOVERSION_PATCH := 2
+LBT_SOVERSION_MINOR := 12
+LBT_SOVERSION_PATCH := 0
 
 ifeq ($(OS), WINNT)
   SHLIB_EXT := dll


### PR DESCRIPTION
We are now going to bump the minor version number even when just including new forwarding symbols, as this technically changes the external API.