### PR TITLE
Makefile: Conform to julia makefile standards

### DIFF
--- a/src/Make.inc
+++ b/src/Make.inc
@@ -118,7 +118,8 @@ endif
 prefix ?= prefix
 builddir ?= build
 
-libdir := $(prefix)/$(binlib)
+shlibdir := $(prefix)/$(binlib)
+libdir := $(prefix)/lib
 includedir := $(prefix)/include
 
 define newline # a literal \n

--- a/src/Makefile
+++ b/src/Makefile
@@ -68,13 +68,13 @@ install: $(TARGET_LIBRARIES)
 	@mkdir -p $(DESTDIR)$(includedir)/libblastrampoline
 	-@cp -Ra $(LBT_ROOT)/include/* $(DESTDIR)$(includedir)/libblastrampoline
 	@cp -a $(LBT_ROOT)/src/libblastrampoline.h $(DESTDIR)$(includedir)/
-	@mkdir -p $(DESTDIR)$(libdir)
+	@mkdir -p $(DESTDIR)$(shlibdir)
 	@for lib in $(TARGET_LIBRARIES); do \
-		cp -a $${lib} $(DESTDIR)$(libdir)/; \
+		cp -a $${lib} $(DESTDIR)$(shlibdir)/; \
 	done
 ifeq ($(OS),WINNT)
-	@mkdir -p $(DESTDIR)$(prefix)/lib
-	@cp -a $(builddir)/$(LIB_MAJOR_VERSION).a $(DESTDIR)$(prefix)/lib
+	@mkdir -p $(DESTDIR)$(libdir)
+	@cp -a $(builddir)/$(LIB_MAJOR_VERSION).a $(DESTDIR)$(libdir)
 endif
 
 clean:


### PR DESCRIPTION
Shared libraries should be installed into $(shlibdir). As is, a julia source build fails on windows without binarybuilder.