### PR TITLE
Add loongarch64 support

### DIFF
--- a/src/libblastrampoline.c
+++ b/src/libblastrampoline.c
@@ -38,6 +38,8 @@ __attribute__((always_inline)) inline uintptr_t get_forward_name_idx() {
     asm("\t mv %0,t4" : "=r"(idx));
 #elif defined(ARCH_x86_64)
     asm("\t movq %%r10,%0" : "=r"(idx));
+#elif defined(ARCH_loongarch64)
+    asm("\t move %0, $t8" : "=r"(idx));
 #else
 #error "Unrecognized ARCH for `get_forward_name_idx()`"
 #endif

--- a/src/trampolines/trampolines_loongarch64.S
+++ b/src/trampolines/trampolines_loongarch64.S
@@ -1,0 +1,20 @@
+#include "common.h"
+#include "../exported_funcs.inc"
+
+#define SEP ;
+
+#define XX(name, idx) \
+.global MANGLE(UNDERSCORE(name)) SEP \
+.cfi_startproc SEP \
+.p2align    2 SEP \
+ MANGLE(UNDERSCORE(name))##: SEP \
+    li.d $t8, SYMBOL_IDX(idx) SEP \
+    la.pcrel $t3, NAMEADDR(name) SEP \
+    ld.d $t3, $t3, 0 SEP \
+    jr $t3 SEP \
+    amswap.w $zero, $zero, $zero SEP \
+.cfi_endproc SEP \
+
+// Generate both `dgemm_` and `dgemm_64_`
+#include "ilp64_doubling.h"
+#undef XX


### PR DESCRIPTION
The original pull request was https://github.com/JuliaLinearAlgebra/libblastrampoline/pull/142 , it can be compiled on native loongarch64 machine, but haven't been tested yet. 