### PR TITLE
Avoid `dlsym()` when finding trampoline addresses

### DIFF
--- a/src/libblastrampoline.c
+++ b/src/libblastrampoline.c
@@ -392,8 +392,8 @@ LBT_DLLEXPORT int32_t lbt_forward(const char * libname, int32_t clear, int32_t v
         // Look up this symbol in the given library, if it is a valid symbol, set it!
         build_symbol_name(symbol_name, exported_func_names[symbol_idx], lib_suffix);
         void *addr = lookup_symbol(handle, symbol_name);
-        void *self_symbol_addr = interface == LBT_INTERFACE_ILP64 ? exported_func64[symbol_idx] \
-                                                                  : exported_func32[symbol_idx];
+        void *self_symbol_addr = interface == LBT_INTERFACE_ILP64 ? self_func64[symbol_idx] \
+                                                                  : self_func32[symbol_idx];
         if (addr == NULL ) {
             // MKL (and other libraries too in the fullness of time, I have no doubt) doesn't like
             // to slap `64` directly onto the end of their symbol names; they insert an extra `_`
@@ -485,17 +485,6 @@ __attribute__((constructor)) void init(void) {
         // on Linux causes a linker error with certain versions of GCC and ld:
         // https://lists.gnu.org/archive/html/bug-binutils/2016-02/msg00191.html
         default_func = lookup_self_symbol("lbt_default_func_print_error_and_exit");
-    }
-
-    // Build our lists of self-symbol addresses
-    int32_t symbol_idx;
-    char symbol_name[MAX_SYMBOL_LEN];
-    for (symbol_idx=0; exported_func_names[symbol_idx] != NULL; ++symbol_idx) {
-        exported_func32[symbol_idx] = lookup_self_symbol(exported_func_names[symbol_idx]);
-
-        // Look up this symbol in the given library, if it is a valid symbol, set it!
-        build_symbol_name(symbol_name, exported_func_names[symbol_idx], "64_");
-        exported_func64[symbol_idx] = lookup_self_symbol(symbol_name);
     }
 
     // LBT_DEFAULT_LIBS is a semicolon-separated list of paths that should be loaded as BLAS libraries.

--- a/src/libblastrampoline_trampdata.h
+++ b/src/libblastrampoline_trampdata.h
@@ -37,13 +37,20 @@ const void ** exported_func64_addrs[] = {
 // Generate list of our own function addresses, so that we can filter
 // out libraries that link against us (such as LAPACK_jll) so that we
 // don't accidentally loop back to ourselves.
-#define XX(name, idx)    NULL,
-#define XX_64(name, idx) NULL,
-const void ** exported_func32[] = {
+#define XX(name, idx)       extern void ** name;
+#define XX_64(name, idx)    extern void ** name##64_;
+EXPORTED_FUNCS(XX)
+EXPORTED_FUNCS(XX_64)
+#undef XX
+#undef XX_64
+
+#define XX(name, idx)       ((const void **)&name),
+#define XX_64(name, idx)    ((const void **)&name##64_),
+const void ** self_func32[] = {
     EXPORTED_FUNCS(XX)
     NULL
 };
-const void ** exported_func64[] = {
+const void ** self_func64[] = {
     EXPORTED_FUNCS(XX_64)
     NULL
 };


### PR DESCRIPTION
We want to avoid using `dlsym()` in our initializer due to [0].  This prompted Gabriel to ask the astute question [1], "Why use `dlsym()` at all here, after all, we have a linker.  Thus, we can avoid all this work entirely by simply having these addresses filled out by the linker at load time.

[0]: https://github.com/JuliaLinearAlgebra/libblastrampoline/issues/163
[1]: https://github.com/JuliaLinearAlgebra/libblastrampoline/pull/164#discussion_r2394909580