### PR TITLE
README: add Reference BLAS and LAPACK to the supported list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ Using [PLT trampolines](https://en.wikipedia.org/wiki/Trampoline_(computing)) to
 These BLAS libraries are known to work with libblastrampoline (successfully tested in Julia):
 
 1. [OpenBLAS](https://github.com/OpenMathLib/OpenBLAS) (supported by default in Julia)
-2. [Intel oneMKL](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) (use in Julia through [MKL.jl](https://github.com/JuliaLinearAlgebra/MKL.jl))
-3. [Apple Accelerate](https://developer.apple.com/documentation/accelerate/blas) (use in Julia through [AppleAccelerate.jl](https://github.com/JuliaMath/AppleAccelerate.jl))
-4. [BLIS](https://github.com/flame/blis/) (use in Julia through [BLISBLAS.jl](https://github.com/carstenbauer/BLISBLAS.jl))
-5. Fujitsu BLAS (use in Julia through [FujitsuBLAS.jl](https://github.com/giordano/FujitsuBLAS.jl))
-6. [ARMPL BLAS](https://developer.arm.com/Tools%20and%20Software/Arm%20Performance%20Libraries)
-7. [NVPL BLAS](https://docs.nvidia.com/nvpl/_static/blas/)
+2. [Reference BLAS and LAPACK](https://github.com/Reference-LAPACK/lapack) (use in Julia through [ReferenceBLAS_jll](https://github.com/JuliaBinaryWrappers/ReferenceBLAS_jll.jl) and [LAPACK_jll](https://github.com/JuliaBinaryWrappers/LAPACK_jll.jl))
+3. [Intel oneMKL](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) (use in Julia through [MKL.jl](https://github.com/JuliaLinearAlgebra/MKL.jl))
+4. [Apple Accelerate](https://developer.apple.com/documentation/accelerate/blas) (use in Julia through [AppleAccelerate.jl](https://github.com/JuliaMath/AppleAccelerate.jl))
+5. [BLIS](https://github.com/flame/blis/) (use in Julia through [BLISBLAS.jl](https://github.com/carstenbauer/BLISBLAS.jl))
+6. Fujitsu BLAS (use in Julia through [FujitsuBLAS.jl](https://github.com/giordano/FujitsuBLAS.jl))
+7. [ARMPL BLAS](https://developer.arm.com/Tools%20and%20Software/Arm%20Performance%20Libraries)
+8. [NVPL BLAS](https://docs.nvidia.com/nvpl/_static/blas/)
 
 ## Basic usage
 


### PR DESCRIPTION
Adds Reference BLAS and LAPACK to the list of supported BLAS libraries in the README, as item 2 (right after OpenBLAS), matching the "use in Julia through …" style of the other entries.

This is the remaining piece of #128 — its test additions and the `dpstrf_test.c` ILP64 fix already landed in #173.

Co-authored-by: Alexis Montoison <alexis.montoison@polymtl.ca>

🤖 Generated with [Claude Code](https://claude.com/claude-code)