### PR TITLE
Deduplicate build files (Makefile + per-test Makefiles)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -32,14 +32,6 @@ MAIN_OBJS += complex_return_style_adapters.o
 # Place the `.o` files into `$(builddir)`
 MAIN_OBJS := $(addprefix $(builddir)/,$(MAIN_OBJS))
 
-ifeq ($(OS),WINNT)
-# On Windows only build the library with the major soversion, all other copies
-# are useless and error prone.
-TARGET_LIBRARIES = $(builddir)/$(LIB_MAJOR_VERSION)
-else
-TARGET_LIBRARIES = $(builddir)/$(LIB_MAJOR_VERSION) $(builddir)/$(LIB_FULL_VERSION) $(builddir)/libblastrampoline.$(SHLIB_EXT)
-endif
-
 $(builddir) $(builddir)/trampolines:
 	@mkdir -p $@
 

--- a/test/cdotc_test/Makefile
+++ b/test/cdotc_test/Makefile
@@ -1,15 +1,1 @@
-include ../../src/Make.inc
-
-all: $(prefix)/cdotc_test$(EXE)
-
-$(prefix):
-	@mkdir -p $@
-
-$(prefix)/cdotc_test$(EXE): cdotc_test.c | $(prefix)
-	@$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS)
-
-clean:
-	@rm -f $(prefix)/cdotc_test$(EXE)
-
-run: $(prefix)/cdotc_test$(EXE)
-	@$(prefix)/cdotc_test$(EXE)
+include ../test.mk

--- a/test/dgemm_test/Makefile
+++ b/test/dgemm_test/Makefile
@@ -1,15 +1,1 @@
-include ../../src/Make.inc
-
-all: $(prefix)/dgemm_test$(EXE)
-
-$(prefix):
-	@mkdir -p $@
-
-$(prefix)/dgemm_test$(EXE): dgemm_test.c | $(prefix)
-	@$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS)
-
-clean:
-	@rm -f $(prefix)/dgemm_test$(EXE)
-
-run: $(prefix)/dgemm_test$(EXE)
-	@$(prefix)/dgemm_test$(EXE)
+include ../test.mk

--- a/test/dgemmt_test/Makefile
+++ b/test/dgemmt_test/Makefile
@@ -1,15 +1,1 @@
-include ../../src/Make.inc
-
-all: $(prefix)/dgemmt_test$(EXE)
-
-$(prefix):
-	@mkdir -p $@
-
-$(prefix)/dgemmt_test$(EXE): dgemmt_test.c | $(prefix)
-	@$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS)
-
-clean:
-	@rm -f $(prefix)/dgemmt_test$(EXE)
-
-run: $(prefix)/dgemmt_test$(EXE)
-	@$(prefix)/dgemmt_test$(EXE)
+include ../test.mk

--- a/test/dpstrf_test/Makefile
+++ b/test/dpstrf_test/Makefile
@@ -1,15 +1,1 @@
-include ../../src/Make.inc
-
-all: $(prefix)/dpstrf_test$(EXE)
-
-$(prefix):
-	@mkdir -p $@
-
-$(prefix)/dpstrf_test$(EXE): dpstrf_test.c | $(prefix)
-	@$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS)
-
-clean:
-	@rm -f $(prefix)/dpstrf_test$(EXE)
-
-run: $(prefix)/dpstrf_test$(EXE)
-	@$(prefix)/dpstrf_test$(EXE)
+include ../test.mk

--- a/test/inconsolable_test/Makefile
+++ b/test/inconsolable_test/Makefile
@@ -1,15 +1,1 @@
-include ../../src/Make.inc
-
-all: $(prefix)/inconsolable_test$(EXE)
-
-$(prefix):
-	@mkdir -p $@
-
-$(prefix)/inconsolable_test$(EXE): inconsolable_test.c | $(prefix)
-	@$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS)
-
-clean:
-	@rm -f $(prefix)/inconsolable_test$(EXE)
-
-run: $(prefix)/inconsolable_test$(EXE)
-	@$(prefix)/inconsolable_test$(EXE)
+include ../test.mk

--- a/test/isamax_test/Makefile
+++ b/test/isamax_test/Makefile
@@ -1,15 +1,1 @@
-include ../../src/Make.inc
-
-all: $(prefix)/isamax_test$(EXE)
-
-$(prefix):
-	@mkdir -p $@
-
-$(prefix)/isamax_test$(EXE): isamax_test.c | $(prefix)
-	@$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS)
-
-clean:
-	@rm -f $(prefix)/isamax_test$(EXE)
-
-run: $(prefix)/isamax_test$(EXE)
-	@$(prefix)/isamax_test$(EXE)
+include ../test.mk

--- a/test/sdot_test/Makefile
+++ b/test/sdot_test/Makefile
@@ -1,15 +1,1 @@
-include ../../src/Make.inc
-
-all: $(prefix)/sdot_test$(EXE)
-
-$(prefix):
-	@mkdir -p $@
-
-$(prefix)/sdot_test$(EXE): sdot_test.c | $(prefix)
-	@$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS)
-
-clean:
-	@rm -f $(prefix)/sdot_test$(EXE)
-
-run: $(prefix)/sdot_test$(EXE)
-	@$(prefix)/sdot_test$(EXE)
+include ../test.mk

--- a/test/sgesv_test/Makefile
+++ b/test/sgesv_test/Makefile
@@ -1,15 +1,1 @@
-include ../../src/Make.inc
-
-all: $(prefix)/sgesv_test$(EXE)
-
-$(prefix):
-	@mkdir -p $@
-
-$(prefix)/sgesv_test$(EXE): sgesv_test.c | $(prefix)
-	@$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS)
-
-clean:
-	@rm -f $(prefix)/sgesv_test$(EXE)
-
-run: $(prefix)/sgesv_test$(EXE)
-	@$(prefix)/sgesv_test$(EXE)
+include ../test.mk

--- a/test/test.mk
+++ b/test/test.mk
@@ -1,0 +1,22 @@
+# Shared build rules for the standalone C test programs under `test/<name>_test/`.
+# Each test directory's Makefile simply does `include ../test.mk`; the test name is
+# derived from the containing directory, so there is no per-test boilerplate to keep
+# in sync.  Invoked by `test/common.jl` as `make -sC test/<name> prefix=... CFLAGS=...`.
+include ../../src/Make.inc
+
+# e.g. `dgemm_test` for `test/dgemm_test/`
+TEST_NAME := $(notdir $(CURDIR))
+
+all: $(prefix)/$(TEST_NAME)$(EXE)
+
+$(prefix):
+	@mkdir -p $@
+
+$(prefix)/$(TEST_NAME)$(EXE): $(TEST_NAME).c | $(prefix)
+	@$(CC) -o $@ $(CFLAGS) $^ $(LDFLAGS)
+
+clean:
+	@rm -f $(prefix)/$(TEST_NAME)$(EXE)
+
+run: $(prefix)/$(TEST_NAME)$(EXE)
+	@$(prefix)/$(TEST_NAME)$(EXE)


### PR DESCRIPTION
## What

Two pieces of pure duplication in the build system:

1. **`src/Makefile`** defined `TARGET_LIBRARIES` twice, identically — the second copy was dead. Removed it.

2. **Eight `test/<name>_test/Makefile`** files were byte-for-byte identical except for the test name (~100 lines of boilerplate). Replaced with a shared **`test/test.mk`** that derives the test name from its directory (`$(notdir $(CURDIR))`). Each per-test Makefile is now a single line:

   ```make
   include ../test.mk
   ```

## Contract preserved

`test/common.jl` still invokes `make -sC test/<name> prefix=... CFLAGS=... LDFLAGS=...` and gets `$(prefix)/<name>$(EXE)` built and `run`-able. Verified by building the library and compiling/linking a real test binary against it through the new shared rule.

## Out of scope (follow-up)

The review also flagged the lack of a `pkg-config`/CMake config export. That's left for a separate PR: LBT ships per-interface (`LP64`/`ILP64`) and per-target headers, so a correct `.pc` is non-trivial and deserves its own discussion.

Draft for review.