### PR TITLE
Tidy internal linkage and two stale/dead details

### DIFF
--- a/src/autodetection.c
+++ b/src/autodetection.c
@@ -249,7 +249,9 @@ int32_t autodetect_interface(void * handle, const char * suffix) {
     // those.
     build_symbol_name(symbol_name, "dpotrf_", suffix);
     void * dpotrf = lookup_symbol(handle, symbol_name);
-    if (ilaver != NULL || dpotrf != NULL) {
+    // NB: if `ilaver` were non-NULL we'd already have returned above, so it's
+    // guaranteed NULL here; only `dpotrf` matters.
+    if (dpotrf != NULL) {
         return autodetect_lapack_interface_dpotrf(dpotrf);
     }
 

--- a/src/config.c
+++ b/src/config.c
@@ -64,7 +64,8 @@ void clear_forwarding_mark(int32_t symbol_idx, int32_t interface) {
     }
 }
 
-void clear_other_forwards(int skip_idx, uint8_t * forwards, int32_t interface) {
+// Only used within this file; keep it out of the library's exported symbols.
+static void clear_other_forwards(int skip_idx, uint8_t * forwards, int32_t interface) {
     for (int idx=0; idx<MAX_TRACKED_LIBS; ++idx) {
         if (lbt_config.loaded_libs[idx] == NULL) {
             return;

--- a/src/libblastrampoline_internal.h
+++ b/src/libblastrampoline_internal.h
@@ -92,7 +92,7 @@ int32_t autodetect_complex_return_style(void * handle, const char * suffix);
 int32_t autodetect_f2c(void * handle, const char * suffix);
 int32_t autodetect_cblas_divergence(void * handle, const char * suffix);
 
-// Functions in deepbindless_surrogates.c
+// Functions in deepbindless.c
 uint8_t push_fake_lsame();
 uint8_t pop_fake_lsame();
 int fake_lsame(char * ca, char * cb);


### PR DESCRIPTION
Three small, behavior-preserving cleanups found during a structural review:

1. **`clear_other_forwards()` had accidental external linkage.** It's used only within `src/config.c` and isn't declared in the internal header, yet it was an exported library symbol. Marked `static` (verified: no longer present in `nm -D` output).

2. **Stale comment** in `src/libblastrampoline_internal.h`: the surrogate functions live in `deepbindless.c`, not `deepbindless_surrogates.c`.

3. **Dead condition** in `autodetect_interface()` (`src/autodetection.c`): the `ilaver != NULL` disjunct can never be true at that point (the function returns earlier when `ilaver` is found), so the guard is simply `dpotrf != NULL`.

Builds cleanly. Draft for review.