### PR TITLE
Add ASAN auto-detect for RTLD_DEEPBIND disable

### DIFF
--- a/src/deepbindless.c
+++ b/src/deepbindless.c
@@ -15,6 +15,19 @@ LBT_DLLEXPORT uint8_t lbt_get_use_deepbind() {
     return use_deepbind;
 }
 
+/*
+ * Returns whether AddressSanitizer is loaded in this process. RTLD_DEEPBIND is
+ * incompatible with the sanitizers' libc interposition
+ * (c.f. https://github.com/google/sanitizers/issues/611)
+ */
+uint8_t running_under_sanitizer(void) {
+#if defined(LBT_DEEPBINDLESS) || !defined(RTLD_DEEPBIND)
+    return 0x00;
+#else
+    return dlsym(RTLD_DEFAULT, "__asan_init") != NULL ? 0x01 : 0x00;
+#endif
+}
+
 
 int lsame_idx = -1;
 const void *old_lsame32 = NULL, *old_lsame64 = NULL;

--- a/src/libblastrampoline.c
+++ b/src/libblastrampoline.c
@@ -520,13 +520,20 @@ __attribute__((constructor)) void init(void) {
         printf("libblastrampoline initializing from %s\n", lookup_self_path());
     }
 
-    // If LBT_USE_RTLD_DEEPBIND == "0", we avoid using RTLD_DEEPBIND on a
-    // deepbind-capable system.  This is mostly useful for sanitizers, which
-    // abhor such library loading shenanigans.
-    if (!env_match_bool("LBT_USE_RTLD_DEEPBIND", 1)) {
+    // If LBT_USE_RTLD_DEEPBIND == "0" or ASAN is auto-detected, we avoid using
+    // RTLD_DEEPBIND on a deepbind-capable system.  This is mostly useful for
+    // sanitizers, which abhor such library loading shenanigans.
+    if (getenv("LBT_USE_RTLD_DEEPBIND") != NULL) {
+        if (!env_match_bool("LBT_USE_RTLD_DEEPBIND", 1)) {
+            use_deepbind = 0x00;
+            if (verbose) {
+                printf("LBT_USE_RTLD_DEEPBIND=0 detected; avoiding usage of RTLD_DEEPBIND\n");
+            }
+        }
+    } else if (running_under_sanitizer()) {
         use_deepbind = 0x00;
         if (verbose) {
-            printf("LBT_USE_RTLD_DEEPBIND=0 detected; avoiding usage of RTLD_DEEPBIND\n");
+            printf("AddressSanitizer detected; avoiding usage of RTLD_DEEPBIND\n");
         }
     }
 

--- a/src/libblastrampoline_internal.h
+++ b/src/libblastrampoline_internal.h
@@ -96,4 +96,5 @@ int32_t autodetect_cblas_divergence(void * handle, const char * suffix);
 uint8_t push_fake_lsame();
 uint8_t pop_fake_lsame();
 int fake_lsame(char * ca, char * cb);
+uint8_t running_under_sanitizer(void);
 extern uint8_t use_deepbind;


### PR DESCRIPTION
It seems like friendly user behavior to try to auto-detect ASAN and disable `RTLD_DEEPBIND` automatically - LBT already supports `LBT_USE_RTLD_DEEPBIND=0` but it's nice not to have to discover that on your own.

Julia is adopting similar detection: https://github.com/JuliaLang/julia/pull/62043